### PR TITLE
travis-ci integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *~
 .*
 !.git*
+!.travis.yml
 *.tar.gz
 *.o
 *.deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: c
+sudo: required
+dist: trusty
+compiler:
+- clang
+- gcc
+os: linux
+before_install:
+- sudo apt-get -qq update
+- sudo apt-get install -y libjson-c-dev libcurl4-gnutls-dev
+before_script:
+- autoreconf -i -f
+- ./configure --disable-silent-rules
+script:
+- make
+- make check
+- make distcheck
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Tlog
 ====
 
+[![Build Status](https://travis-ci.org/Scribery/tlog.svg?branch=master)](https://travis-ci.org/Scribery/tlog)
+
 `Tlog` is a terminal I/O recording and playback package suitable for
 implementing [centralized user session recording][session_recording].
 At the moment it is not ready for production and is to be considered


### PR DESCRIPTION
Hello,
this is an attempt to integrate the Scribery/tlog repository with the travis-ci CI platform. I guess I'll need admin access to the organization to complete the integration, or you (@spbnick) will have to do it. What needs to be done is:
 - [x] Create the travis-ci Scribery account (log in via Github)
 - [x] Enable and configure the repository at travis-ci.org
