### PR TITLE
CI: Enable coverage testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 - CONFIGURE_ARGS="" DISTCHECK=yes
 - CONFIGURE_ARGS="--enable-debug" DISTCHECK=yes
 - CONFIGURE_ARGS="--disable-debug" DISTCHECK=yes
-- COVERAGE=yes CFLAGS="--coverage" LDFLAGS="--coverage"
+- COVERAGE=yes CFLAGS="--coverage" LDFLAGS="--coverage" CONFIGURE_ARGS="--enable-debug"
 - CLANG_SCAN_BUILD="scan-build --status-bugs"
 compiler:
 - clang
@@ -15,6 +15,7 @@ before_install:
 - sudo apt-get -qq update
 - sudo apt-get install -y libjson-c-dev libcurl4-gnutls-dev
 - sudo apt-get install -y clang
+- sudo apt-get install -y lcov
 - gem install coveralls-lcov
 before_script:
 - autoreconf -i -f
@@ -24,4 +25,4 @@ script:
 - $CLANG_SCAN_BUILD make check
 - test "x$DISTCHECK" = xyes && make distcheck || true
 after_success:
-- test "x$COVERAGE" = xyes && lcov --compat-libtool --directory . --capture --output-file coverage.info && coveralls-lcov coverage.info
+- test "x$COVERAGE" = xyes -a "x$CC" = "xgcc" && lcov --compat-libtool --directory . --capture --output-file coverage.info && coveralls-lcov coverage.info

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Tlog
 ====
 
 [![Build Status](https://travis-ci.org/Scribery/tlog.svg?branch=master)](https://travis-ci.org/Scribery/tlog)
+[![Coverage Status](https://coveralls.io/repos/github/Scribery/tlog/badge.svg?branch=master)](https://coveralls.io/github/Scribery/tlog?branch=master)
 
 `Tlog` is a terminal I/O recording and playback package suitable for
 implementing [centralized user session recording][session_recording].


### PR DESCRIPTION
 - Enable coverage testing by installing the lcov utility inside the
   travis sandbox.
 - Limit the coverage testing to GCC builds only as lcov doesn't seem
   to be able to process gcda files from a clang compiled project.
 - Add a coverage badge to the main README.md file.