### PR TITLE
Add support for -v/--version options

### DIFF
--- a/include/tlog/misc.h
+++ b/include/tlog/misc.h
@@ -32,6 +32,9 @@
 #include <stdint.h>
 #include <tlog/grc.h>
 
+/** Tlog version and license information */
+extern const char *tlog_version;
+
 /** Return number of elements in an array */
 #define TLOG_ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -20,12 +20,23 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "config.h"
 #include <tlog/rc.h>
 #include <tlog/misc.h>
 #include <libgen.h>
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
+
+const char *tlog_version =
+    PACKAGE_STRING "\n"
+    "Copyright (C) 2015-2016 Red Hat\n"
+    "License GPLv2+: GNU GPL version 2 or later "
+        "<http://gnu.org/licenses/gpl.html>.\n"
+    "\n"
+    "This is free software: "
+        "you are free to change and redistribute it.\n"
+    "There is NO WARRANTY, to the extent permitted by law.\n";
 
 tlog_grc
 tlog_build_or_inst_path(char          **ppath,

--- a/m4/tlog/play_conf_schema.m4
+++ b/m4/tlog/play_conf_schema.m4
@@ -81,6 +81,11 @@ M4_PARAM(`', `help', `opts',
          `h', `', `Output a command-line usage message and exit',
          `M4_LINES(`')')m4_dnl
 m4_dnl
+M4_PARAM(`', `version', `opts',
+         `M4_TYPE_BOOL(false)', true,
+         `v', `', `Output version information and exit',
+         `M4_LINES(`')')m4_dnl
+m4_dnl
 M4_PARAM(`', `follow', `opts',
          `M4_TYPE_BOOL(false)', true,
          `f', `', `Wait for and play back new messages',

--- a/m4/tlog/rec_conf_schema.m4
+++ b/m4/tlog/rec_conf_schema.m4
@@ -81,6 +81,11 @@ M4_PARAM(`', `help', `opts',
          `h', `', `Output a command-line usage message and exit',
          `M4_LINES(`')')m4_dnl
 m4_dnl
+M4_PARAM(`', `version', `opts',
+         `M4_TYPE_BOOL(false)', true,
+         `v', `', `Output version information and exit',
+         `M4_LINES(`')')m4_dnl
+m4_dnl
 M4_PARAM(`', `shell', `file',
          `M4_TYPE_STRING(`/bin/bash')', true,
          `s', `=SHELL', `Spawn the specified SHELL',

--- a/src/tlog-play.c
+++ b/src/tlog-play.c
@@ -233,6 +233,15 @@ run(const char *progname, struct json_object *conf)
         }
     }
 
+    /* Check for the version flag */
+    if (json_object_object_get_ex(conf, "version", &obj)) {
+        if (json_object_get_boolean(obj)) {
+            printf("%s", tlog_version);;
+            grc = TLOG_RC_OK;
+            goto cleanup;
+        }
+    }
+
     /* Get the "follow" flag */
     follow = json_object_object_get_ex(conf, "follow", &obj) &&
              json_object_get_boolean(obj);

--- a/src/tlog-rec.c
+++ b/src/tlog-rec.c
@@ -995,6 +995,15 @@ run(const char *progname, struct json_object *conf,
         }
     }
 
+    /* Check for the version flag */
+    if (json_object_object_get_ex(conf, "version", &obj)) {
+        if (json_object_get_boolean(obj)) {
+            printf("%s", tlog_version);;
+            grc = TLOG_RC_OK;
+            goto cleanup;
+        }
+    }
+
     /* Read the log latency */
     if (!json_object_object_get_ex(conf, "latency", &obj)) {
         fprintf(stderr, "Log latency is not specified\n");


### PR DESCRIPTION
Add support for outputting version and licensing information to tlog-rec
and tlog-play, using -v/--version options.

Fixes #2.