### PR TITLE
Tolerate errors while checking for build dir

### DIFF
--- a/lib/misc.c
+++ b/lib/misc.c
@@ -95,7 +95,7 @@ tlog_build_or_inst_path(char          **ppath,
                 goto cleanup;
             }
         }
-    } else if (errno != ENOENT) {
+    } else if (errno != ENOENT && errno != EACCES && errno != ENOTDIR) {
         grc = TLOG_GRC_ERRNO;
         goto cleanup;
     }


### PR DESCRIPTION
While checking if a program runs from the build dir, ignore EACCES and
ENOTDIR, assuming it is not a build dir, as those errors shouldn't
happen there.

OTOH, EACCESS happens when running `su user` with user shell being
`tlog-rec`, while being in another user's home directory, because a
simple `su` doesn't change the directory and realpath breaks when
current dir cannot be read.

Fixes #79