### PR TITLE
Use localstatedir not runstatedir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,4 +25,4 @@ dist_doc_DATA = README.md
 dist_noinst_DATA = tlog.spec
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)@runstatedir@/tlog
+	$(MKDIR_P) $(DESTDIR)@localstatedir@/run/tlog


### PR DESCRIPTION
Base lock directory under localstatedir, instead of runstatedir, as the
latter is only available on Debian.