### PR TITLE
Rhel6 build fixes

### DIFF
--- a/include/tlog/errs.h
+++ b/include/tlog/errs.h
@@ -36,6 +36,7 @@
 #define _TLOG_ERRS_H
 
 #include <stdio.h>
+#include <stdarg.h>
 #include <tlog/grc.h>
 #include <tlog/rc.h>
 

--- a/src/tlog-rec.c
+++ b/src/tlog-rec.c
@@ -247,9 +247,7 @@ session_lock(struct tlog_errs **perrs, unsigned int id,
      * FIXME Handle repeating session IDs.
      */
     EVAL_WITH_EUID_EGID(perrs, euid, egid,
-                        fd = open(path,
-                                  O_CREAT | O_CLOEXEC | O_EXCL,
-                                  S_IRUSR | S_IWUSR));
+                        fd = open(path, O_CREAT | O_EXCL, S_IRUSR | S_IWUSR));
     if (fd < 0) {
         int open_errno = errno;
         tlog_grc open_grc = TLOG_GRC_ERRNO;


### PR DESCRIPTION
Although this fixes the build, it doesn't make tlog work on RHEL5. As RHEL5 kernel doesn't expose session ID in the procfs.