### PR TITLE
Add logging rate limiting support

### DIFF
--- a/include/tlog/Makefile.am
+++ b/include/tlog/Makefile.am
@@ -59,6 +59,7 @@ tlog_HEADERS = \
     rec_session_conf.h          \
     rec_session_conf_cmd.h      \
     rec_session_conf_validate.h \
+    rl_json_writer.h            \
     session.h                   \
     sink.h                      \
     sink_type.h                 \

--- a/include/tlog/json_source.h
+++ b/include/tlog/json_source.h
@@ -81,7 +81,7 @@ extern bool tlog_json_source_params_is_valid(
                             const struct tlog_json_source_params *params);
 
 /**
- * Create (allocate and initialize) a log source.
+ * Create (allocate and initialize) a JSON source.
  *
  * @param psource   Location for created source pointer,
  *                  set to NULL in case of error.

--- a/include/tlog/json_source.h
+++ b/include/tlog/json_source.h
@@ -66,6 +66,12 @@ struct tlog_json_source_params {
     const char                 *terminal;
     /** Session ID to filter log messages by, 0 for unfiltered */
     unsigned int                session_id;
+    /**
+     * Ignore missing messages, i.e. message ID jumps, if true,
+     * return TLOG_RC_JSON_SOURCE_MSG_ID_OUT_OF_ORDER, if a missing
+     * message is detected, if false.
+     */
+    bool                        lax;
     /** Size of I/O data buffer used in packets */
     size_t                      io_size;
 };

--- a/include/tlog/json_writer.h
+++ b/include/tlog/json_writer.h
@@ -62,6 +62,8 @@ extern bool tlog_json_writer_is_valid(const struct tlog_json_writer *writer);
 
 /**
  * Write with a writer.
+ * Atomic, i.e. always writes everything, or nothing,
+ * unless an error beside EINTR occurs.
  *
  * @param writer    The writer to write with.
  * @param id        ID of the message in the buffer. Cannot be zero.
@@ -69,6 +71,8 @@ extern bool tlog_json_writer_is_valid(const struct tlog_json_writer *writer);
  * @param len       The length of the message buffer to write.
  *
  * @return Global return code.
+ *         Can return TLOG_GRC_FROM(errno, EINTR), if writing was interrupted
+ *         by a signal before anything was written.
  */
 extern tlog_grc tlog_json_writer_write(struct tlog_json_writer *writer,
                                        size_t id,

--- a/include/tlog/json_writer_type.h
+++ b/include/tlog/json_writer_type.h
@@ -61,6 +61,8 @@ typedef bool (*tlog_json_writer_type_is_valid_fn)(
 
 /**
  * Message writing function prototype.
+ * Atomic, i.e. always writes everything, or nothing,
+ * unless an error beside EINTR occurs.
  *
  * @param writer    The writer to operate on.
  * @param id        ID of the message in the buffer. Cannot be zero.
@@ -68,6 +70,8 @@ typedef bool (*tlog_json_writer_type_is_valid_fn)(
  * @param len       The length of the message buffer to write.
  *
  * @return Global return code.
+ *         Can return TLOG_GRC_FROM(errno, EINTR), if writing was interrupted
+ *         by a signal before anything was written.
  */
 typedef tlog_grc (*tlog_json_writer_type_write_fn)(
                                 struct tlog_json_writer *writer,

--- a/include/tlog/mem_json_writer.h
+++ b/include/tlog/mem_json_writer.h
@@ -32,7 +32,7 @@
 #include <tlog/json_writer.h>
 
 /**
- * File descriptor message writer type
+ * Memory buffer JSON message writer type
  *
  * Creation arguments:
  *
@@ -45,7 +45,7 @@ extern const struct tlog_json_writer_type tlog_mem_json_writer_type;
 /**
  * Create an instance of memory buffer writer.
  *
- * @param pwriter   The writer to initialize.
+ * @param pwriter   Location for the pointer to the created writer.
  * @param pbuf      Location for the allocated buffer pointer.
  * @param plen      Location for the length of the buffer contents. The memory
  *                  allocated for the buffer can be larger.

--- a/include/tlog/rl_json_writer.h
+++ b/include/tlog/rl_json_writer.h
@@ -1,0 +1,72 @@
+/**
+ * @file
+ * @brief Rate-limiting JSON message writer.
+ *
+ * Rate-limiting JSON writer passes messages written to it to a "below"
+ * writer, calculating and limiting their rate and "burstiness". Each written
+ * message size is compared to the specified rate and burst threshold. If it
+ * passes, then the message is written to the "below" writer. If it fails the
+ * check, then, depending on creation parameters, it is either discarded and
+ * the writer reports success, or the write to the "below" writer is delayed
+ * until the message conforms to the rate and the burst threshold.
+ */
+/*
+ * Copyright (C) 2017 Red Hat
+ *
+ * This file is part of tlog.
+ *
+ * Tlog is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Tlog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with tlog; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _TLOG_RL_JSON_WRITER_H
+#define _TLOG_RL_JSON_WRITER_H
+
+#include <assert.h>
+#include <tlog/json_writer.h>
+
+/** Rate-limiting JSON message writer type */
+extern const struct tlog_json_writer_type tlog_rl_json_writer_type;
+
+/**
+ * Create an instance of rate-limiting writer.
+ *
+ * @param pwriter       Location for the pointer to the created writer.
+ * @param below         The "below" writer to write messages to.
+ * @param below_owned   True if the "below" writer should be destroyed when
+ *                      the created rate limit writer is destroyed.
+ * @param clock_id      ID of the clock to use to calculate message rate and
+ *                      to delay messages.
+ * @param rate          Average message data rate, bytes per second.
+ * @param burst         Maximum message burst size, bytes.
+ * @param drop          False if writing a message exceeding maximum rate
+ *                      should be delayed until it fits, true if the message
+ *                      should be discarded instead.
+ *
+ * @return Global return code.
+ */
+static inline tlog_grc
+tlog_rl_json_writer_create(struct tlog_json_writer **pwriter,
+                           struct tlog_json_writer *below, bool below_owned,
+                           clockid_t clock_id,
+                           size_t rate, size_t burst, bool drop)
+{
+    assert(pwriter != NULL);
+    assert(tlog_json_writer_is_valid(below));
+    return tlog_json_writer_create(pwriter, &tlog_rl_json_writer_type,
+                                   below, below_owned, clock_id,
+                                   rate, burst, drop);
+}
+
+#endif /* _TLOG_RL_JSON_WRITER_H */

--- a/include/tlog/sink.h
+++ b/include/tlog/sink.h
@@ -75,6 +75,8 @@ extern bool tlog_sink_is_valid(const struct tlog_sink *sink);
  *              position right after the end of the packet.
  *
  * @return Global return code.
+ *         Can return TLOG_GRC_FROM(errno, EINTR), if ppos wasn't NULL, and
+ *         writing was interrupted by a signal before anything was written.
  */
 extern tlog_grc tlog_sink_write(struct tlog_sink *sink,
                                 const struct tlog_pkt *pkt,
@@ -87,6 +89,8 @@ extern tlog_grc tlog_sink_write(struct tlog_sink *sink,
  * @param sink  The sink to cut I/O for.
  *
  * @return Global return code.
+ *         Can return TLOG_GRC_FROM(errno, EINTR), if writing was attempted
+ *         and interrupted by a signal before anything was written.
  */
 extern tlog_grc tlog_sink_cut(struct tlog_sink *sink);
 
@@ -96,6 +100,8 @@ extern tlog_grc tlog_sink_cut(struct tlog_sink *sink);
  * @param sink  The sink to flush.
  *
  * @return Global return code.
+ *         Can return TLOG_GRC_FROM(errno, EINTR), if writing was attempted
+ *         and interrupted by a signal before anything was written.
  */
 extern tlog_grc tlog_sink_flush(struct tlog_sink *sink);
 

--- a/include/tlog/sink_type.h
+++ b/include/tlog/sink_type.h
@@ -68,6 +68,8 @@ typedef bool (*tlog_sink_type_is_valid_fn)(const struct tlog_sink *sink);
  * @param end   Position in the packet the write should end at.
  *
  * @return Global return code.
+ *         Can return TLOG_GRC_FROM(errno, EINTR), if writing was interrupted
+ *         by a signal before anything was written.
  */
 typedef tlog_grc (*tlog_sink_type_write_fn)(struct tlog_sink *sink,
                                             const struct tlog_pkt *pkt,

--- a/include/tlog/tap.h
+++ b/include/tlog/tap.h
@@ -31,6 +31,7 @@
 #include <tlog/errs.h>
 #include <termios.h>
 #include <unistd.h>
+#include <time.h>
 
 /** I/O tap state */
 struct tlog_tap {
@@ -68,6 +69,7 @@ struct tlog_tap {
  * @param in_fd     Stdin to connect to, or -1 if none.
  * @param out_fd    Stdout to connect to, or -1 if none.
  * @param err_fd    Stderr to connect to, or -1 if none.
+ * @param clock_id  Clock to use for timestamps.
  *
  * @return Global return code.
  */
@@ -76,7 +78,8 @@ extern tlog_grc tlog_tap_setup(struct tlog_errs **perrs,
                                uid_t euid, gid_t egid,
                                unsigned int opts,
                                const char *path, char **argv,
-                               int in_fd, int out_fd, int err_fd);
+                               int in_fd, int out_fd, int err_fd,
+                               clockid_t clock_id);
 
 /**
  * Teardown an I/O tap state.

--- a/include/tlog/timespec.h
+++ b/include/tlog/timespec.h
@@ -221,6 +221,20 @@ tlog_timespec_is_zero(const struct timespec *t)
 }
 
 /**
+ * Check if a timespec is negative.
+ *
+ * @param t     Timespec to check.
+ *
+ * @return True if the timespec is negative, false otherwise.
+ */
+static inline bool
+tlog_timespec_is_negative(const struct timespec *t)
+{
+    assert(tlog_timespec_is_valid(t));
+    return t->tv_sec < 0 || t->tv_nsec < 0;
+}
+
+/**
  * Compare two timespec's.
  *
  * @param a     First timespec to compare.

--- a/include/tlog/timespec.h
+++ b/include/tlog/timespec.h
@@ -208,6 +208,20 @@ extern void tlog_timespec_fp_div(const struct timespec *a,
                                  struct timespec *res);
 
 /**
+ * Check if a timespec is negative (not positive and not zero).
+ *
+ * @param t     Timespec to check.
+ *
+ * @return True if the timespec is negative, false otherwise.
+ */
+static inline bool
+tlog_timespec_is_negative(const struct timespec *t)
+{
+    assert(tlog_timespec_is_valid(t));
+    return t->tv_sec < 0 || t->tv_nsec < 0;
+}
+
+/**
  * Check if a timespec is zero.
  *
  * @param t     Timespec to check.
@@ -221,17 +235,18 @@ tlog_timespec_is_zero(const struct timespec *t)
 }
 
 /**
- * Check if a timespec is negative.
+ * Check if a timespec is positive, (not negative and not zero).
  *
  * @param t     Timespec to check.
  *
- * @return True if the timespec is negative, false otherwise.
+ * @return True if the timespec is positive, false otherwise.
  */
 static inline bool
-tlog_timespec_is_negative(const struct timespec *t)
+tlog_timespec_is_positive(const struct timespec *t)
 {
     assert(tlog_timespec_is_valid(t));
-    return t->tv_sec < 0 || t->tv_nsec < 0;
+    return (t->tv_sec > 0 && t->tv_nsec >= 0) ||
+           (t->tv_sec >= 0 && t->tv_nsec > 0);
 }
 
 /**

--- a/include/tlog/tty_sink.h
+++ b/include/tlog/tty_sink.h
@@ -31,12 +31,7 @@
 
 #include <tlog/sink.h>
 
-/**
- * TTY sink type
- *
- * Creation arguments:
- *
- */
+/** TTY sink type */
 extern const struct tlog_sink_type tlog_tty_sink_type;
 
 /**

--- a/include/tlog/tty_source.h
+++ b/include/tlog/tty_source.h
@@ -34,16 +34,11 @@
 /** Minimum size of the I/O buffer */
 #define TLOG_TTY_SOURCE_IO_SIZE_MIN 32
 
-/**
- * TTY source type
- *
- * Creation arguments:
- *
- */
+/** TTY source type */
 extern const struct tlog_source_type tlog_tty_source_type;
 
 /**
- * Create (allocate and initialize) a log source.
+ * Create (allocate and initialize) a TTY source.
  *
  * @param psource   Location for created source pointer, set to NULL
  *                  in case of error.

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -136,6 +136,7 @@ libtlog_la_SOURCES = \
     rec_session_conf.c          \
     rec_session_conf_cmd.c      \
     rec_session_conf_validate.c \
+    rl_json_writer.c            \
     session.c                   \
     sink.c                      \
     source.c                    \

--- a/lib/fd_json_writer.c
+++ b/lib/fd_json_writer.c
@@ -60,13 +60,15 @@ tlog_fd_json_writer_write(struct tlog_json_writer *writer,
     struct tlog_fd_json_writer *fd_json_writer =
                                     (struct tlog_fd_json_writer*)writer;
     ssize_t rc;
+    const uint8_t *p = buf;
 
     (void)id;
 
     while (true) {
-        rc = write(fd_json_writer->fd, buf, len);
+        rc = write(fd_json_writer->fd, p, len);
         if (rc < 0) {
-            if (errno == EINTR) {
+            /* If interrupted after writing something */
+            if (errno == EINTR && p > buf) {
                 continue;
             } else {
                 return TLOG_GRC_ERRNO;
@@ -75,7 +77,7 @@ tlog_fd_json_writer_write(struct tlog_json_writer *writer,
         if ((size_t)rc == len) {
             return TLOG_RC_OK;
         }
-        buf += rc;
+        p += rc;
         len -= (size_t)rc;
     }
 }

--- a/lib/rec.c
+++ b/lib/rec.c
@@ -881,7 +881,9 @@ tlog_rec_transfer(struct tlog_errs    **perrs,
         if (new_alarm_caught != last_alarm_caught) {
             alarm_set = false;
             grc = tlog_sink_flush(log_sink);
-            if (grc != TLOG_RC_OK) {
+            if (grc == TLOG_GRC_FROM(errno, EINTR)) {
+                continue;
+            } else if (grc != TLOG_RC_OK) {
                 tlog_errs_pushc(perrs, grc);
                 tlog_errs_pushs(perrs, "Failed flushing log");
                 return_grc = grc;

--- a/lib/rec.c
+++ b/lib/rec.c
@@ -916,14 +916,14 @@ tlog_rec_transfer(struct tlog_errs    **perrs,
             /* If asked to log this type of packet */
             if (item_mask & (1 << tlog_rec_item_from_pkt(&pkt))) {
                 grc = tlog_sink_write(log_sink, &pkt, &log_pos, NULL);
-                if (grc != TLOG_RC_OK &&
-                    grc != TLOG_GRC_FROM(errno, EINTR)) {
+                if (grc == TLOG_RC_OK) {
+                    log_pending = true;
+                } else if (grc != TLOG_GRC_FROM(errno, EINTR)) {
                     tlog_errs_pushc(perrs, grc);
                     tlog_errs_pushs(perrs, "Failed logging terminal data");
                     return_grc = grc;
                     goto cleanup;
                 }
-                log_pending = true;
             } else {
                 tlog_pkt_pos_move_past(&log_pos, &pkt);
             }

--- a/lib/rl_json_writer.c
+++ b/lib/rl_json_writer.c
@@ -1,0 +1,190 @@
+/*
+ * Rate-limiting JSON message writer.
+ *
+ * Copyright (C) 2017 Red Hat
+ *
+ * This file is part of tlog.
+ *
+ * Tlog is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Tlog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with tlog; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <tlog/timespec.h>
+#include <tlog/rc.h>
+#include <tlog/rl_json_writer.h>
+
+/** Rate-limiting writer data */
+struct tlog_rl_json_writer {
+    /** Abstract writer instance */
+    struct tlog_json_writer     writer;
+    /** "Below" writer the packets should be written to */
+    struct tlog_json_writer    *below;
+    /** True if "below" writer should be destroyed with us */
+    bool                        below_owned;
+    /** ID of the clock to use for calculating rate and delaying */
+    clockid_t                   clock_id;
+    /**
+     * Average message rate limit, bytes per second.
+     * Type is chosen to be compatible with timestamps.
+     */
+    struct timespec             rate;
+    /**
+     * Maximum message burst size, bytes.
+     * Type is chosen to be compatible with timestamps.
+     */
+    struct timespec             burst;
+    /**
+     * Bucket limit (rate + burst), bytes.
+     * Type is chosen to be compatible with timestamps.
+     */
+    struct timespec             limit;
+    /** True if messages exceeding rate should be dropped, false if delayed */
+    bool                        drop;
+    /** True if the writer synced time and bucket previously */
+    bool                        synced;
+    /** Last sync timestamp */
+    struct timespec             last_sync;
+    /**
+     * "Leaky bucket" of message sizes.
+     * Type is chosen to be compatible with timestamps.
+     */
+    struct timespec             bucket;
+};
+
+static tlog_grc
+tlog_rl_json_writer_init(struct tlog_json_writer *writer, va_list ap)
+{
+    struct tlog_rl_json_writer *rl_json_writer =
+                                    (struct tlog_rl_json_writer*)writer;
+    rl_json_writer->below = va_arg(ap, struct tlog_json_writer *);
+    assert(tlog_json_writer_is_valid(rl_json_writer->below));
+    rl_json_writer->below_owned = va_arg(ap, int) != 0;
+    rl_json_writer->clock_id = va_arg(ap, clockid_t);
+    rl_json_writer->rate.tv_sec = (time_t)va_arg(ap, size_t);
+    rl_json_writer->burst.tv_sec = (time_t)va_arg(ap, size_t);
+    tlog_timespec_add(&rl_json_writer->rate, &rl_json_writer->burst,
+                      &rl_json_writer->limit);
+    rl_json_writer->drop = va_arg(ap, int) != 0;
+    return TLOG_RC_OK;
+}
+
+static bool
+tlog_rl_json_writer_is_valid(const struct tlog_json_writer *writer)
+{
+    struct tlog_rl_json_writer *rl_json_writer =
+                                    (struct tlog_rl_json_writer*)writer;
+    return rl_json_writer != NULL &&
+           tlog_json_writer_is_valid(rl_json_writer->below) &&
+           tlog_timespec_is_valid(&rl_json_writer->rate) &&
+           tlog_timespec_is_valid(&rl_json_writer->burst) &&
+           (!rl_json_writer->synced ||
+            tlog_timespec_is_valid(&rl_json_writer->last_sync)) &&
+           tlog_timespec_cmp(&rl_json_writer->bucket,
+                             &rl_json_writer->limit) <= 0;
+}
+
+static void
+tlog_rl_json_writer_cleanup(struct tlog_json_writer *writer)
+{
+    struct tlog_rl_json_writer *rl_json_writer =
+                                    (struct tlog_rl_json_writer*)writer;
+    assert(rl_json_writer != NULL);
+    if (rl_json_writer->below_owned) {
+        tlog_json_writer_destroy(rl_json_writer->below);
+    }
+    rl_json_writer->below = NULL;
+}
+
+static tlog_grc
+tlog_rl_json_writer_write(struct tlog_json_writer *writer,
+                           size_t id, const uint8_t *buf, size_t len)
+{
+    struct tlog_rl_json_writer *rl_json_writer =
+                                    (struct tlog_rl_json_writer*)writer;
+    tlog_grc grc;
+    int rc;
+    struct timespec now;
+    struct timespec poured = {.tv_sec = len, .tv_nsec = 0};
+    struct timespec bucket_poured;
+    struct timespec overflow;
+
+    /*
+     * Sync (drain) the bucket to the time
+     */
+    if (clock_gettime(rl_json_writer->clock_id, &now) < 0) {
+        return TLOG_GRC_ERRNO;
+    }
+
+    if (rl_json_writer->synced) {
+        struct timespec elapsed;
+        struct timespec drained;
+        tlog_timespec_sub(&now, &rl_json_writer->last_sync, &elapsed);
+        tlog_timespec_fp_mul(&elapsed, &rl_json_writer->rate, &drained);
+        tlog_timespec_sub(&rl_json_writer->bucket, &drained,
+                          &rl_json_writer->bucket);
+        if (tlog_timespec_is_negative(&rl_json_writer->bucket)) {
+            rl_json_writer->bucket = TLOG_TIMESPEC_ZERO;
+        }
+    } else {
+        rl_json_writer->synced = true;
+    }
+    rl_json_writer->last_sync = now;
+
+    /*
+     * Try to fit the message into the bucket
+     */
+    tlog_timespec_add(&rl_json_writer->bucket, &poured, &bucket_poured);
+    tlog_timespec_sub(&bucket_poured, &rl_json_writer->limit, &overflow);
+    /* If the bucket would overflow */
+    if (tlog_timespec_is_positive(&overflow)) {
+        /* If dropping */
+        if (rl_json_writer->drop) {
+            /* Report success without writing */
+            return TLOG_RC_OK;
+        } else {
+            struct timespec delay;
+            struct timespec wakeup;
+            /* Wait until the message fits */
+            tlog_timespec_fp_div(&overflow, &rl_json_writer->rate, &delay);
+            tlog_timespec_add(&rl_json_writer->last_sync, &delay, &wakeup);
+            rc = clock_nanosleep(rl_json_writer->clock_id, TIMER_ABSTIME,
+                                 &wakeup, NULL);
+            if (rc != 0) {
+                return TLOG_GRC_FROM(errno, rc);
+            }
+            bucket_poured = rl_json_writer->limit;
+            now = wakeup;
+        }
+    }
+
+    /*
+     * Write the message and pour it into bucket
+     */
+    grc = tlog_json_writer_write(rl_json_writer->below, id, buf, len);
+    if (grc != TLOG_RC_OK) {
+        return grc;
+    }
+    rl_json_writer->bucket = bucket_poured;
+    rl_json_writer->last_sync = now;
+
+    return TLOG_RC_OK;
+}
+
+const struct tlog_json_writer_type tlog_rl_json_writer_type = {
+    .size       = sizeof(struct tlog_rl_json_writer),
+    .init       = tlog_rl_json_writer_init,
+    .is_valid   = tlog_rl_json_writer_is_valid,
+    .cleanup    = tlog_rl_json_writer_cleanup,
+    .write      = tlog_rl_json_writer_write,
+};

--- a/lib/timespec.c
+++ b/lib/timespec.c
@@ -74,6 +74,15 @@ tlog_timespec_add(const struct timespec *a,
         }
     }
 
+    /* Carry from sec */
+    if (tmp.tv_sec < 0 && tmp.tv_nsec > 0) {
+        tmp.tv_sec++;
+        tmp.tv_nsec -= 1000000000;
+    } else if (tmp.tv_sec > 0 && tmp.tv_nsec < 0) {
+        tmp.tv_sec--;
+        tmp.tv_nsec += 1000000000;
+    }
+
     *res = tmp;
     assert(tlog_timespec_is_valid(res));
 }
@@ -105,6 +114,15 @@ tlog_timespec_sub(const struct timespec *a,
             tmp.tv_sec--;
             tmp.tv_nsec += 1000000000;
         }
+    }
+
+    /* Carry from sec */
+    if (tmp.tv_sec < 0 && tmp.tv_nsec > 0) {
+        tmp.tv_sec++;
+        tmp.tv_nsec -= 1000000000;
+    } else if (tmp.tv_sec > 0 && tmp.tv_nsec < 0) {
+        tmp.tv_sec--;
+        tmp.tv_nsec += 1000000000;
     }
 
     *res = tmp;
@@ -158,6 +176,15 @@ tlog_timespec_cap_add(const struct timespec *a,
         }
     }
 
+    /* Carry from sec */
+    if (tmp.tv_sec < 0 && tmp.tv_nsec > 0) {
+        tmp.tv_sec++;
+        tmp.tv_nsec -= 1000000000;
+    } else if (tmp.tv_sec > 0 && tmp.tv_nsec < 0) {
+        tmp.tv_sec--;
+        tmp.tv_nsec += 1000000000;
+    }
+
     *res = tmp;
 exit:
     assert(tlog_timespec_is_valid(res));
@@ -208,6 +235,15 @@ tlog_timespec_cap_sub(const struct timespec *a,
             tmp.tv_sec--;
             tmp.tv_nsec += 1000000000;
         }
+    }
+
+    /* Carry from sec */
+    if (tmp.tv_sec < 0 && tmp.tv_nsec > 0) {
+        tmp.tv_sec++;
+        tmp.tv_nsec -= 1000000000;
+    } else if (tmp.tv_sec > 0 && tmp.tv_nsec < 0) {
+        tmp.tv_sec--;
+        tmp.tv_nsec += 1000000000;
     }
 
     *res = tmp;

--- a/m4/tlog/play_conf_schema.m4
+++ b/m4/tlog/play_conf_schema.m4
@@ -107,3 +107,9 @@ M4_PARAM(`', `persist', `file-',
          `', `', `Ignore quit key and signals from keyboard',
          `M4_LINES(`If true, ignore any keyboard-generated signals and the quit key.')')m4_dnl
 m4_dnl
+M4_PARAM(`', `lax', `file-',
+         `M4_TYPE_BOOL(false)', true,
+         `', `', `Ignore missing (dropped) log messages',
+         `M4_LINES(`If true, ignore missing (dropped, or lost) log messages.',
+                   `If false, report an error and abort when a message is missing.')')m4_dnl
+m4_dnl

--- a/m4/tlog/rec_common_conf_schema.m4
+++ b/m4/tlog/rec_common_conf_schema.m4
@@ -59,6 +59,28 @@ _M4_PARAM(`/log', `window', `file-',
 m4_dnl
 m4_dnl
 m4_dnl
+M4_CONTAINER(`', `/limit', `Logging limit')m4_dnl
+m4_dnl
+_M4_PARAM(`/limit', `rate', `file-',
+          `M4_TYPE_INT(16384, 0)', true,
+          `', `=NUMBER', `Set logging rate limit to NUMBER of message bytes/sec',
+          `M4_LINES(`Maximum rate messages could be logged at, bytes/sec.')')m4_dnl
+m4_dnl
+_M4_PARAM(`/limit', `burst', `file-',
+          `M4_TYPE_INT(32768, 0)', true,
+          `', `=NUMBER', `Set logging burst limit to NUMBER of message bytes',
+          `M4_LINES(`Number of bytes by which logged messages are allowed to exceed',
+                    `the rate limit momentarily, i.e. "burstiness", bytes.')')m4_dnl
+m4_dnl
+_M4_PARAM(`/limit', `action', `file-',
+          `M4_TYPE_CHOICE(`pass', `pass', `delay', `drop')', true,
+          `', `=STRING', `Perform STRING action above limits (pass/delay/drop)',
+          `M4_LINES(`If set to "pass" no logging limits will be applied.',
+                    `If set to "delay", logging will be throttled.',
+                    `If set to "drop", messages exceeding limits will be dropped.')')m4_dnl
+m4_dnl
+m4_dnl
+m4_dnl
 M4_CONTAINER(`', `/file', `File writer')m4_dnl
 m4_dnl
 _M4_PARAM(`/file', `path', `file-',

--- a/m4/tlog/rec_session_conf_schema.m4
+++ b/m4/tlog/rec_session_conf_schema.m4
@@ -51,6 +51,9 @@ M4_PARAM(`', `notice', `file-env',
                    `recording and the user shell. Can be used to warn',
                    `the user that the session is recorded.')')m4_dnl
 m4_dnl
+m4_dnl
+m4_dnl Include common schema, but limit its scope to environment
+m4_dnl
 m4_pushdef(`_M4_PARAM', `M4_PARAM(`$1', `$2', `$3env', m4_shiftn(3, $@))')m4_dnl
 m4_include(`rec_common_conf_schema.m4')m4_dnl
 m4_popdef(`_M4_PARAM')m4_dnl

--- a/man/tlog-play.8.m4
+++ b/man/tlog-play.8.m4
@@ -71,11 +71,11 @@ rate).
 
 .TP
 .B G
-Fast-forward the recording to the end, or to specified time. Works on pause.
-The time can be specified by typing in a timestamp before pressing 'G'. The
-timestamp should follow the format of the -g/--goto option value, but without
-the fractions of a second. The command has no effect, if the specified time
-location has already been reached.
+Fast-forward the recording to the end, or to specified time. Works while
+playing and on pause. The time can be specified by typing in a timestamp
+before pressing 'G'. The timestamp should follow the format of the -g/--goto
+option value, but without the fractions of a second. The command has no
+effect, if the specified time location has already been reached.
 
 E.g. pressing just 'G' would fast-forward to the end, which is useful with
 following enabled. Pressing '3', '0', 'G' (typing "30G") would fast-forward to

--- a/notes.txt
+++ b/notes.txt
@@ -961,3 +961,133 @@ string, similar to what journalctl accepts to filter out the required session.
 One problem can be specifying the time from which we should play. The journal
 API provides sd_journal_seek_realtime_usec and sd_journal_seek_monotonic_usec,
 which we can perhaps use by taking a separate journal source option.
+---
+So, rate limiting is not letting us log more than a specified amount of I/O
+bytes per time unit. Let's say per hour.
+
+The way we calculate that could be having an averaging time window, or just
+calculate from the start of the recording.
+
+current_rate = bytes / hours
+
+How would we choose what to drop, though?
+Should we just do
+
+    if current_rate > target_rate then
+        drop
+    else
+        pass
+
+What should be the quantum of dropping, then? A packet?
+
+----------------
+Leaky bucket for raw data, both input and output
+Either drop or hold the packets
+Consider providing maximum packet size configuration
+Consider doing it for encoded data later
+Add configuration parameter/option for bytes per second
+
+----------------
+The pass decision is for a packet.
+We can simply say every piece of it is written when dropping.
+We can simply wait on the first piece when delaying.
+----------------
+
+We need to either assume that packet timestamps are in local time,
+or take our own time samples. Because we cannot advance abstract packet
+recording time, if it is not local time. For that matter, to make the rate
+limit sink more universal we need to ignore packet timestamps and take our own
+timestamps.
+
+---------------
+
+So, we don't need to know local time if we are just dropping packets, we only
+need packet timestamps.
+
+We can drop packets based on their timestamps, or based on times when they're
+written. We can only delay packets based on writing timestamps.
+
+Having limit based on packet timestamps would be useful for testing.
+
+We would need rate limit set on the log sink, right? Right.
+
+What if we give the rate limit sink some time source function instead of
+letting it get its own time?
+
+What timestamps should delayed packets have? Original ones, or delayed? Should
+the recording reflect timestamps the packets were output by the recorded
+program and input by the user, or the timestamps they were delivered at?
+If we follow the idea of "recording what users saw on the screen", then it
+should be delivery time.
+
+Ha! Should we actually rate-limit the source instead? Then we can adjust
+packet timestamps and take time samples freely! For the start we can just give
+the rate-limit source a clock ID, but in the future we can pass it a function
+which would generate timestamps, and let us do testing at any actual speed
+required. We would also have no problem with packet fragments, as sources
+don't have any.
+
+The rate limit sink will have to assume that the time source for packets is
+the same time source it was given. We can later introduce a notion of
+"abstract time", which would have timestamp retrieval and time-advancing
+(sleeping) functions. We can have one specific time for
+clock_gettime/nanosleep, and one for testing time.
+
+Right. We can't rate-limit source, because we will be dropping data sent to
+the user terminal and entered by the user. We have to rate-limit the log sink.
+
+Would it be right to change the timestamp of packets sent to the log?
+No it likely wouldn't.
+
+Should we have delay at the TTY source, but dropping at the log sink?
+Even if we had delay at the TTY source, would it be right to change packet
+timestamp? For that matter, what the packet timestamp should be? Time of
+arrival, or time of departure? And should input and output rather be both
+measured at the tlog<->program interface, and not input at tty<->tlog and
+output at tlog<->program interfaces? Or both at tty<->tlog interface, as the
+user saw it? From the point of correlating with other logs, the right way
+would be to record time at the tlog<->program interface, as that would be
+closer to other events in the system. The tty<->tlog interface is just a
+display, after all. What about window resizes? That should be the same as
+input.
+
+For that matter, if we did throttling (delaying) at the source, then only
+input and window timestamps should be updated, and we wouldn't really be able
+to use packet timestamps for rate control. However, since we don't let any
+packets pass until we log them, and we can't really control logging latency,
+we can only log source timestamps.
+
+But should we log only before passing the I/O? If not, then when should we log
+it? Should we log it after passing a single packet? Why a single packet then?
+Why not two? What if it's a single *big* packet? No, we should log *before*
+passing the packet, or rather we log any data, before passing it on.
+
+To avoid the mess of timestamps, we can just assume that timestamp is opaque
+packet data, and deal only with rate related to the provided clock. Then we
+can implement rate-limit sink, simply, covering all the features.
+
+What if we're asked to write only a part of a packet, and it doesn't pass,
+but a later part passes? Do we write a fragment only? Apparently yes.
+So dropping/delaying quanta becomes a packet fragment.
+
+Should we allow a part of packet fragment through, if only a part fits?
+
+We should let whatever fits through immediately, and drop/delay the rest.
+
+We need to do the pkt_pos math properly. Support adding and subtracting. Both
+should round to the closest possible value, just like floating point does.
+Should they cap at maximum?
+
+ppos + free, cap at end
+if more than zero, write
+if less than end, delay until what's left can fit
+
+First purpose of pkt_pos: track progress of writing packets.
+I.e. we need to mark where we were and where we've gone until all of the
+packet is written
+Second purpose of pkt_pos: calculating payload size and converting payload
+size to position to write from and until
+
+No, we're not going to be rate-limiting at the packet level. First of all,
+encoded size can be wildly different, then it will be hard to tell if anything
+was dropped or not. We need to rate-limit at the JSON writer sink.

--- a/src/tlog-play.c
+++ b/src/tlog-play.c
@@ -263,13 +263,19 @@ create_log_source(struct tlog_errs **perrs,
         goto cleanup;
     }
 
-    /* Create the source */
+    /*
+     * Create the source
+     */
     {
         struct tlog_json_source_params params = {
             .reader = reader,
             .reader_owned = true,
             .io_size = 4096,
         };
+        /* Get the "lax" flag */
+        params.lax = json_object_object_get_ex(conf, "lax", &obj) &&
+                     json_object_get_boolean(obj);
+        /* Create the source */
         grc = tlog_json_source_create(&source, &params);
         if (grc != TLOG_RC_OK) {
             tlog_errs_pushc(perrs, grc);

--- a/src/tlog-test-timespec.c
+++ b/src/tlog-test-timespec.c
@@ -128,6 +128,8 @@ main(void)
     TEST(all_sub, TS(1, 0), TS(2, 1), TS(-1, -1));
     TEST(all_sub, TS(1, 1), TS(2, 2), TS(-1, -1));
     TEST(all_sub, TS(-1, 0), TS(0, 1), TS(-1, -1));
+    TEST(all_sub, TS(-1, 0), TS(0, -1), TS(0, -999999999));
+    TEST(all_sub, TS(-1, 0), TS(0, 1), TS(-1, -1));
     TEST(all_sub, TS(-1, 0), TS(-1, 0), TS(0, 0));
     TEST(all_sub, TS(-1, 0), TS(-1, -1), TS(0, 1));
     TEST(all_sub, TS(-1, -1), TS(-1, -1), TS(0, 0));
@@ -136,6 +138,8 @@ main(void)
     TEST(all_sub, TS(0, -999999999), TS(0, 2), TS(-1, -1));
     TEST(all_sub, TS(0, 999999999), TS(0, -1), TS(1, 0));
     TEST(all_sub, TS(0, 999999999), TS(0, -2), TS(1, 1));
+    TEST(all_sub, TS(1, 500000000), TS(2, 0), TS(0, -500000000));
+    TEST(all_sub, TS(-1, -500000000), TS(-2, 0), TS(0, 500000000));
     TEST(int_sub, TS(0, 0), tlog_timespec_max, TS(LONG_MIN + 1, -999999999));
 
     TEST(sub, tlog_timespec_min, TS(0, 1), TS(LONG_MAX, 0));
@@ -181,9 +185,13 @@ main(void)
     TEST(all_add, TS(0, -999999999), TS(0, -1), TS(-1, 0));
     TEST(all_add, TS(0, -999999999), TS(0, -2), TS(-1, -1));
     TEST(all_add, TS(-1, 0), TS(0, 1), TS(0, -999999999));
+    TEST(all_add, TS(-1, 0), TS(0, -1), TS(-1, -1));
+    TEST(all_add, TS(-1, 0), TS(0, 1), TS(0, -999999999));
     TEST(all_add, TS(-1, -1), TS(0, 1), TS(-1, 0));
     TEST(all_add, TS(-1, -1), TS(0, 2), TS(0, -999999999));
     TEST(all_add, TS(-1, 0), TS(0, -1), TS(-1, -1));
+    TEST(all_add, TS(-1, -500000000), TS(2, 0), TS(0, 500000000));
+    TEST(all_add, TS(1, 500000000), TS(-2, 0), TS(0, -500000000));
 
     TEST(int_add, TS(LONG_MAX / 2, 500000000), TS(LONG_MAX / 2, 500000000),
                   TS(LONG_MAX, 0));


### PR DESCRIPTION
This PR adds support for specifying maximum rate limit and "burstiness" of logged messages, plus the desired action: should the limit be ignored, logging (and I/O) delayed, or messages dropped to comply.

Correspondingly, this adds support for ignoring missing (dropped) messages to tlog-play.

This also fixes a problem where input (including Ctrl-C and such) would be ignored if recorded program produced a lot of output, and a few minor problems regarding EINTR handling.