### PR TITLE
Issue configuration raw mode in termios

### DIFF
--- a/include/tlog/es_json_reader.h
+++ b/include/tlog/es_json_reader.h
@@ -1,9 +1,9 @@
 /**
  * @file
- * @brief ElasticSearch JSON message reader.
+ * @brief Elasticsearch JSON message reader.
  *
  * An implementation of a reader retrieving JSON log messages from
- * ElasticSearch, provided base URL and a query.
+ * Elasticsearch, provided base URL and a query.
  */
 /*
  * Copyright (C) 2015 Red Hat
@@ -32,27 +32,27 @@
 #include <tlog/json_reader.h>
 
 /**
- * Minimum number of messages to request from ElasticSearch in one HTTP
+ * Minimum number of messages to request from Elasticsearch in one HTTP
  * request
  */
 #define TLOG_ES_JSON_READER_SIZE_MIN 1
 
 /**
- * ElasticSearch message reader type
+ * Elasticsearch message reader type
  *
  * Creation arguments:
  *
- * const char  *base_url    The base URL to request ElasticSearch, without the
+ * const char  *base_url    The base URL to request Elasticsearch, without the
  *                          query or the fragment parts.
  * const char  *query       The query string to send to ElastiSearch.
- * size_t       size        Number of messages to request from ElasticSearch
+ * size_t       size        Number of messages to request from Elasticsearch
  *                          in one HTTP request.
  *
  */
 extern const struct tlog_json_reader_type tlog_es_json_reader_type;
 
 /**
- * Check if a base URL is valid for use with an ElasticSearch reader, that is,
+ * Check if a base URL is valid for use with an Elasticsearch reader, that is,
  * if it doesn't contain the query (?...) or the fragment (#...) parts.
  *
  * @param base_url   The base URL to check.
@@ -62,14 +62,14 @@ extern const struct tlog_json_reader_type tlog_es_json_reader_type;
 extern bool tlog_es_json_reader_base_url_is_valid(const char *base_url);
 
 /**
- * Create an ElasticSearch reader.
+ * Create an Elasticsearch reader.
  *
  * @param preader   Location for the created reader pointer, will be set to
  *                  NULL in case of error.
- * @param base_url  The base URL to request ElasticSearch, without the query
+ * @param base_url  The base URL to request Elasticsearch, without the query
  *                  or the fragment parts.
  * @param query     The query string to send to ElastiSearch.
- * @param size      Number of messages to request from ElasticSearch in one
+ * @param size      Number of messages to request from Elasticsearch in one
  *                  HTTP request.
  *
  * @return Global return code.

--- a/lib/es_json_reader.c
+++ b/lib/es_json_reader.c
@@ -1,5 +1,5 @@
 /*
- * ElasticSearch JSON message reader.
+ * Elasticsearch JSON message reader.
  *
  * Copyright (C) 2015 Red Hat
  *
@@ -30,7 +30,7 @@
 #include <tlog/es_json_reader.h>
 #include <tlog/rc.h>
 
-/** ElasticSearch reader data */
+/** Elasticsearch reader data */
 struct tlog_es_json_reader {
     struct tlog_json_reader     reader;     /**< Base type */
     CURL                       *curl;       /**< libcurl handle */
@@ -80,15 +80,15 @@ tlog_es_json_reader_cleanup(struct tlog_json_reader *reader)
 }
 
 /**
- * Format an ElasticSearch request URL prefix: the URL ending with "from=",
+ * Format an Elasticsearch request URL prefix: the URL ending with "from=",
  * ready for the addition of the message index.
  *
  * @param purl_pfx  The location for the dynamically-allocated URL prefix.
  * @param curl      The CURL handle to escape with.
- * @param base_url  The base URL to request ElasticSearch, without the query
+ * @param base_url  The base URL to request Elasticsearch, without the query
  *                  or the fragment parts.
  * @param query     The query string to send to ElastiSearch.
- * @param size      Number of messages to request from ElasticSearch in one
+ * @param size      Number of messages to request from Elasticsearch in one
  *                  HTTP request.
  *
  * @return Global return code.
@@ -287,7 +287,7 @@ tlog_es_json_reader_loc_fmt(const struct tlog_json_reader *reader,
 }
 
 /**
- * Format an ElasticSearch request URL for the current message index of a
+ * Format an Elasticsearch request URL for the current message index of a
  * reader.
  *
  * @param reader    The reader to format the URL for.

--- a/m4/tlog/play_conf_schema.m4
+++ b/m4/tlog/play_conf_schema.m4
@@ -65,18 +65,18 @@ M4_PARAM(`/file', `path', `file-',
 m4_dnl
 m4_dnl
 m4_dnl
-M4_CONTAINER(`', `/es', `ElasticSearch reader')m4_dnl
+M4_CONTAINER(`', `/es', `Elasticsearch reader')m4_dnl
 m4_dnl
 M4_PARAM(`/es', `baseurl', `file-',
          `M4_TYPE_STRING()', false,
-         `', `=STRING', `ElasticSearch URL without query or fragment parts',
-         `M4_LINES(`The base URL to request ElasticSearch through. Should not',
+         `', `=STRING', `Elasticsearch URL without query or fragment parts',
+         `M4_LINES(`The base URL to request Elasticsearch through. Should not',
                    `contain the query (?...) or fragment (#...) parts.')')m4_dnl
 m4_dnl
 M4_PARAM(`/es', `query', `file-',
          `M4_TYPE_STRING()', false,
-         `', `=STRING', `ElasticSearch query',
-         `M4_LINES(`The query string to send to ElasticSearch')')m4_dnl
+         `', `=STRING', `Elasticsearch query',
+         `M4_LINES(`The query string to send to Elasticsearch')')m4_dnl
 m4_dnl
 m4_dnl
 m4_dnl

--- a/man/tlog-play.8.m4
+++ b/man/tlog-play.8.m4
@@ -102,7 +102,7 @@ Play back a recording from Journal:
 .B tlog-play -r journal -M TLOG_REC=6071524bb44d403991a00413ab7c8596-53bd-378c5d9
 
 .TP
-Play back a recording from ElasticSearch:
+Play back a recording from Elasticsearch:
 .B tlog-play -r es --es-baseurl=http://localhost:9200/tlog/tlog/_search --es-query=session:121
 
 .SH SEE ALSO

--- a/man/tlog-play.conf.5.m4
+++ b/man/tlog-play.conf.5.m4
@@ -53,7 +53,7 @@ A config specifying only the reader:
 .fi
 
 .TP
-A config specifying ElasticSearch reader, along with the base URL.
+A config specifying Elasticsearch reader, along with the base URL.
 .nf
 
 {


### PR DESCRIPTION
According TERMIOS(3), 
cfmakeraw() sets the terminal to something like the "raw" mode of the old Version 7 terminal driver: input is available character by character, echoing is disabled, and all special processing of terminal input and output characters is disabled. The terminal attributes are set as follows:
```
    termios_p->c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP
                    | INLCR | IGNCR | ICRNL | IXON);
    termios_p->c_oflag &= ~OPOST;
    termios_p->c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
    termios_p->c_cflag &= ~(CSIZE | PARENB);
    termios_p->c_cflag |= CS8;
```
If ECHONL and ICANON are set the '\n' character shall be echoed even if the ECHO is not set.  From this link: https://www.mkssoftware.com/docs/man5/struct_termios.5.asp