### PR TITLE
update configuration raw mode in termios

### DIFF
--- a/src/tlog-play.c
+++ b/src/tlog-play.c
@@ -513,10 +513,12 @@ run(struct tlog_errs **perrs,
      * but keep signal generation, if not persistent
      */
     raw_termios = orig_termios;
-    raw_termios.c_lflag &= ~(ICANON | IEXTEN | ECHO | (persist ? ISIG : 0));
+    raw_termios.c_lflag &= ~(ICANON | IEXTEN | ECHO | ECHONL | (persist ? ISIG : 0));
     raw_termios.c_iflag &= ~(BRKINT | ICRNL | IGNBRK | IGNCR | INLCR |
                              INPCK | ISTRIP | IXON | PARMRK);
     raw_termios.c_oflag &= ~OPOST;
+    raw_termios.c_cflag &= ~(CSIZE | PARENB);
+    raw_termios.c_cflag |= CS8;
     raw_termios.c_cc[VMIN] = 1;
     raw_termios.c_cc[VTIME] = 0;
     rc = tcsetattr(STDOUT_FILENO, TCSAFLUSH, &raw_termios);


### PR DESCRIPTION
According TERMIOS(3),
cfmakeraw() sets the terminal to something like the "raw" mode of the old Version 7 terminal driver: input is available character by character, echoing is disabled, and all special processing of terminal input and output characters is disabled. The terminal attributes are set as follows:
```c
    termios_p->c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP
                    | INLCR | IGNCR | ICRNL | IXON);
    termios_p->c_oflag &= ~OPOST;
    termios_p->c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
    termios_p->c_cflag &= ~(CSIZE | PARENB);
    termios_p->c_cflag |= CS8;
```
It makes sure that you do not have any bugs in raw mode in termios. It is important because tlog_play will use raw mode in termios to record, in which terminal is the noncanonical mode, with all input and output processing, as well as echoing, switched off. 