### PR TITLE
Add line, function name for debug file

### DIFF
--- a/include/tlog/test_json_sink.h
+++ b/include/tlog/test_json_sink.h
@@ -86,7 +86,7 @@ struct tlog_test_json_sink {
     const char                     *output;
 };
 
-extern bool tlog_test_json_sink(const char *name,
+extern bool tlog_test_json_sink(const char *file, int line, const char *name,
                                 const struct tlog_test_json_sink test);
 
 #endif /* _TLOG_TEST_JSON_SINK_H */

--- a/include/tlog/test_json_source.h
+++ b/include/tlog/test_json_source.h
@@ -93,7 +93,7 @@ struct tlog_test_json_source {
     struct tlog_test_json_source_output     output;
 };
 
-extern bool tlog_test_json_source(const char *name,
+extern bool tlog_test_json_source(const char *file, int line, const char *name,
                                   const struct tlog_test_json_source test);
 
 #endif /* _TLOG_TEST_JSON_SOURCE_H */

--- a/include/tlog/test_json_stream_enc.h
+++ b/include/tlog/test_json_stream_enc.h
@@ -65,6 +65,8 @@ struct tlog_test_json_stream_enc {
  * @return True if test passed, false otherwise.
  */
 extern bool tlog_test_json_stream_enc(
+                        const char *file,
+                        int line,
                         const char *n,
                         const struct tlog_test_json_stream_enc t);
 

--- a/lib/test_json_sink.c
+++ b/lib/test_json_sink.c
@@ -135,7 +135,8 @@ cleanup:
 }
 
 bool
-tlog_test_json_sink(const char *name, const struct tlog_test_json_sink test)
+tlog_test_json_sink(const char *file, int line, const char *name,
+                    const struct tlog_test_json_sink test)
 {
     bool passed = true;
     const char *exp_output_buf = test.output;
@@ -159,6 +160,6 @@ tlog_test_json_sink(const char *name, const struct tlog_test_json_sink test)
 
     free(res_output_buf);
 
-    fprintf(stderr, "%s: %s\n", name, (passed ? "PASS" : "FAIL"));
+    fprintf(stderr, "%s %s:%d %s\n",(passed ? "PASS" : "FAIL"), file, line, name);
     return passed;
 }

--- a/lib/test_json_source.c
+++ b/lib/test_json_source.c
@@ -207,7 +207,7 @@ tlog_test_json_source_run(
 }
 
 bool
-tlog_test_json_source(const char *name,
+tlog_test_json_source(const char *file, int line, const char *name,
                       const struct tlog_test_json_source test)
 {
     bool passed;
@@ -215,6 +215,7 @@ tlog_test_json_source(const char *name,
     passed = tlog_test_json_source_run(name,
                                        test.input, strlen(test.input),
                                        &test.output);
-    fprintf(stderr, "%s: %s\n", name, (passed ? "PASS" : "FAIL"));
+    fprintf(stderr, "%s %s:%d %s\n", (passed ? "PASS" : "FAIL"),
+            file, line, name);
     return passed;
 }

--- a/lib/test_json_stream_enc.c
+++ b/lib/test_json_stream_enc.c
@@ -102,7 +102,7 @@ test_meta_init(struct test_meta *meta, size_t rem)
 }
 
 bool
-tlog_test_json_stream_enc(const char *n,
+tlog_test_json_stream_enc(const char *file, int line, const char *n,
                           const struct tlog_test_json_stream_enc t)
 {
     bool passed = true;
@@ -157,7 +157,8 @@ tlog_test_json_stream_enc(const char *n,
 #undef CMP_SIZE
 #undef CMP_BOOL
 #undef FAIL
-    fprintf(stderr, "%s: %s\n", n, (passed ? "PASS" : "FAIL"));
+    fprintf(stderr, "%s %s:%d %s\n", (passed ? "PASS" : "FAIL"),
+            file, line, n);
 
     return passed;
 }

--- a/src/tlog-test-fd-json-reader.c
+++ b/src/tlog-test-fd-json-reader.c
@@ -77,7 +77,7 @@ struct test {
 };
 
 static bool
-test(const char *n, const struct test t)
+test(const char *file, int line, const char *n, const struct test t)
 {
     bool passed = true;
     int fd = -1;
@@ -121,9 +121,10 @@ test(const char *n, const struct test t)
     }
 
 #define FAIL(_fmt, _args...) \
-    do {                                                \
-        fprintf(stderr, "%s: " _fmt "\n", n, ##_args);  \
-        passed = false;                                 \
+    do {                                              \
+        fprintf(stderr, "FAIL %s:%d %s " _fmt "\n",   \
+                file, line, n, ##_args);              \
+        passed = false;                               \
     } while (0)
 
 #define FAIL_OP(_fmt, _args...) \
@@ -192,7 +193,8 @@ test(const char *n, const struct test t)
 #undef FAIL_OP
 #undef FAIL
 
-    fprintf(stderr, "%s: %s\n", n, (passed ? "PASS" : "FAIL"));
+    fprintf(stderr, "%s %s:%d %s\n", (passed ? "PASS" : "FAIL"),
+            file, line, n);
 
     tlog_json_reader_destroy(reader);
     if (fd >= 0) {
@@ -218,7 +220,7 @@ main(void)
      .data = {.loc_get = {.exp_loc = _exp_loc}}}
 
 #define TEST(_name_token, _input, _op_list_init_args...) \
-    passed = test(#_name_token,                                 \
+    passed = test(__FILE__, __LINE__, #_name_token,             \
                   (struct test){                                \
                     .input = _input,                            \
                     .op_list = {_op_list_init_args, OP_NONE}    \
@@ -490,4 +492,3 @@ main(void)
 
     return !passed;
 }
-

--- a/src/tlog-test-grc.c
+++ b/src/tlog-test-grc.c
@@ -31,9 +31,10 @@
 #include <tlog/rc.h>
 
 bool
-test(const char *name, bool res)
+test(const char *file, int line, const char *name, bool res)
 {
-    fprintf(stderr, "%s: %s\n", name, (res ? "PASS" : "FAIL"));
+    fprintf(stderr, "%s %s:%d %s\n", (res ? "PASS" : "FAIL"),
+            file, line, name);
     return res;
 }
 
@@ -43,7 +44,7 @@ main(void)
     bool passed = true;
 
 #define TEST(_name_token, _expr) \
-    passed = test(#_name_token, _expr) && passed
+    passed = test(__FILE__, __LINE__, #_name_token, _expr) && passed
 
     TEST(invalid, !tlog_grc_is_valid(INT_MAX));
 

--- a/src/tlog-test-json-esc.c
+++ b/src/tlog-test-json-esc.c
@@ -30,7 +30,8 @@
 #define BOOL_STR(_x) ((_x) ? "true" : "false")
 
 static bool
-test(const char *name, size_t exp_res_len,
+test(const char *file, int line,
+     const char *name, size_t exp_res_len,
      const char *out_ptr, size_t out_len,
      const char *in_ptr, size_t in_len)
 {
@@ -50,9 +51,10 @@ test(const char *name, size_t exp_res_len,
     res_res_len = tlog_json_esc_buf(res_out_buf, out_len, in_ptr, in_len);
 
 #define FAIL(_fmt, _args...) \
-    do {                                                    \
-        fprintf(stderr, "%s: " _fmt "\n", name, ##_args);   \
-        passed = false;                                     \
+    do {                                                            \
+        fprintf(stderr, "FAIL %s:%d %s " _fmt "\n", file, line,     \
+                name, ##_args);                                     \
+        passed = false;                                             \
     } while (0)
 #define TEST(_expr, _fmt, _args...) \
     do {                            \
@@ -69,7 +71,8 @@ test(const char *name, size_t exp_res_len,
     }
 #undef TEST
 #undef FAIL
-    fprintf(stderr, "%s: %s\n", name, (passed ? "PASS" : "FAIL"));
+    fprintf(stderr, "%s %s:%d %s\n", (passed ? "PASS" : "FAIL"),
+            file, line, name);
     return passed;
 }
 
@@ -81,7 +84,7 @@ main(void)
 #define TEST_BUF_BUF(_name_token, _exp_res_len, \
                      _out_ptr, _out_len, _in_ptr, _in_len)              \
     do {                                                                \
-        passed = test(#_name_token, _exp_res_len,                       \
+        passed = test(__FILE__, __LINE__, #_name_token, _exp_res_len,   \
                       _out_ptr, _out_len, _in_ptr, _in_len) && passed;  \
     } while (0);
 

--- a/src/tlog-test-json-overlay.c
+++ b/src/tlog-test-json-overlay.c
@@ -29,7 +29,9 @@
 #include <assert.h>
 
 bool
-test(const char *name,
+test(const char *file,
+     int line,
+     const char *name,
      const char *lower_text,
      const char *upper_text,
      const char *exp_result_text)
@@ -81,7 +83,8 @@ test(const char *name,
                        exp_result_len);
     }
 
-    fprintf(stderr, "%s: %s\n", name, (passed ? "PASS" : "FAIL"));
+    fprintf(stderr, "%s %s:%d %s\n", (passed ? "PASS" : "FAIL"),
+            file, line, name);
 
     json_object_put(lower);
     json_object_put(upper);
@@ -96,7 +99,8 @@ main(void)
     bool passed = true;
 
 #define TEST(_name_token, _lower, _upper, _result) \
-    passed = test(#_name_token, _lower, _upper, _result) && passed
+    passed = test(__FILE__, __LINE__, #_name_token,   \
+                  _lower, _upper, _result) && passed  \
 
     TEST(empty, "{ }", "{ }", "{ }");
 

--- a/src/tlog-test-json-passthrough.c
+++ b/src/tlog-test-json-passthrough.c
@@ -41,7 +41,9 @@ struct tlog_test_json_passthrough {
 };
 
 static bool
-tlog_test_json_passthrough(const char *name,
+tlog_test_json_passthrough(const char *file,
+                           int line,
+                           const char *name,
                            struct tlog_test_json_passthrough test)
 {
     bool passed = true;
@@ -72,7 +74,8 @@ tlog_test_json_passthrough(const char *name,
              passed;
 
 exit:
-    fprintf(stderr, "%s: %s\n", name, (passed ? "PASS" : "FAIL"));
+    fprintf(stderr, "%s %s:%d %s\n", (passed ? "PASS" : "FAIL"),
+            file, line, name);
     if (!passed) {
         fprintf(stderr, "%s log:\n%.*s", name, (int)log_len, log_buf);
     }
@@ -272,7 +275,7 @@ main(void)
 
 #define TEST(_name_token, _struct_init_args...) \
     passed = tlog_test_json_passthrough(                \
-                #_name_token,                           \
+                __FILE__, __LINE__, #_name_token,       \
                 (struct tlog_test_json_passthrough){    \
                     _struct_init_args                   \
                 }                                       \

--- a/src/tlog-test-json-sink.c
+++ b/src/tlog-test-json-sink.c
@@ -66,6 +66,7 @@ main(void)
 
 #define TEST(_name_token, _struct_init_args...) \
     passed = tlog_test_json_sink(               \
+                __FILE__, __LINE__,             \
                 #_name_token,                   \
                 (struct tlog_test_json_sink){   \
                     _struct_init_args           \

--- a/src/tlog-test-json-source.c
+++ b/src/tlog-test-json-source.c
@@ -87,6 +87,7 @@ main(void)
 
 #define TEST(_name_token, _struct_init_args...) \
     passed = tlog_test_json_source(             \
+                __FILE__, __LINE__,             \
                 #_name_token,                   \
                 (struct tlog_test_json_source){ \
                     _struct_init_args           \

--- a/src/tlog-test-json-stream-enc-bin.c
+++ b/src/tlog-test-json-stream-enc-bin.c
@@ -29,7 +29,7 @@ main(void)
     bool passed = true;
 
 #define TEST(_name_token, _struct_init_args...) \
-    passed = tlog_test_json_stream_enc(#_name_token,                        \
+    passed = tlog_test_json_stream_enc(__FILE__, __LINE__, #_name_token,    \
                                   (struct tlog_test_json_stream_enc)        \
                                        {.func = tlog_json_stream_enc_bin,   \
                                         ##_struct_init_args}) &&            \

--- a/src/tlog-test-json-stream-enc-txt.c
+++ b/src/tlog-test-json-stream-enc-txt.c
@@ -30,7 +30,7 @@ main(void)
     bool passed = true;
 
 #define TEST(_name_token, _struct_init_args...) \
-    passed = tlog_test_json_stream_enc(#_name_token,                        \
+    passed = tlog_test_json_stream_enc(__FILE__, __LINE__, #_name_token,    \
                                   (struct tlog_test_json_stream_enc)        \
                                        {.func = tlog_json_stream_enc_txt,   \
                                         ##_struct_init_args}) &&            \

--- a/src/tlog-test-json-stream.c
+++ b/src/tlog-test-json-stream.c
@@ -195,7 +195,7 @@ test_meta_cleanup(struct test_meta *meta)
 }
 
 static bool
-test(const char *n, const struct test t)
+test(const char *file, int line, const char *n, const struct test t)
 {
     bool passed = true;
     struct test_meta meta;
@@ -213,9 +213,10 @@ test(const char *n, const struct test t)
     last_rem = meta.rem;
 
 #define FAIL(_fmt, _args...) \
-    do {                                                \
-        fprintf(stderr, "%s: " _fmt "\n", n, ##_args);  \
-        passed = false;                                 \
+    do {                                                          \
+        fprintf(stderr, "FAIL %s:%d %s" _fmt "\n", file, line,    \
+                n, ##_args);                                      \
+        passed = false;                                           \
     } while (0)
 
 #define FAIL_OP(_fmt, _args...) \
@@ -326,7 +327,8 @@ test(const char *n, const struct test t)
 #undef BUF_CMP
 
 #undef FAIL
-    fprintf(stderr, "%s: %s\n", n, (passed ? "PASS" : "FAIL"));
+    fprintf(stderr, "%s %s:%d %s\n", (passed ? "PASS" : "FAIL"),
+            file, line, n);
 
 cleanup:
     test_meta_cleanup(&meta);
@@ -339,7 +341,8 @@ main(void)
     bool passed = true;
 
 #define TEST(_name_token, _struct_init_args...) \
-    passed = test(#_name_token, (struct test){_struct_init_args}) && passed
+    passed = test(__FILE__, __LINE__, #_name_token,     \
+                  (struct test){_struct_init_args}) && passed
 
 #define OP_WRITE(_data_init_args...) \
     {.type = OP_TYPE_WRITE, .data = {.write = {_data_init_args}}}

--- a/src/tlog-test-timespec.c
+++ b/src/tlog-test-timespec.c
@@ -35,7 +35,8 @@ struct op {
 };
 
 static bool
-op_list_test(const struct op *op_list, size_t op_num,
+op_list_test(const char *file, int line,
+             const struct op *op_list, size_t op_num,
              struct timespec a, struct timespec b, struct timespec exp_res)
 {
     bool all_passed = true;
@@ -48,15 +49,17 @@ op_list_test(const struct op *op_list, size_t op_num,
         passed = (res.tv_sec == exp_res.tv_sec && res.tv_nsec == exp_res.tv_nsec);
         if (passed) {
             fprintf(stderr,
-                    "PASS " TLOG_TIMESPEC_FMT " %s " TLOG_TIMESPEC_FMT
+                    "PASS %s:%d " TLOG_TIMESPEC_FMT " %s " TLOG_TIMESPEC_FMT
                     " == " TLOG_TIMESPEC_FMT "\n",
+                    file, line,
                     TLOG_TIMESPEC_ARG(&a), op_list[i].sym,
                     TLOG_TIMESPEC_ARG(&b),
                     TLOG_TIMESPEC_ARG(&exp_res));
         } else {
             fprintf(stderr,
-                    "FAIL " TLOG_TIMESPEC_FMT " %s " TLOG_TIMESPEC_FMT
+                    "FAIL %s:%d " TLOG_TIMESPEC_FMT " %s " TLOG_TIMESPEC_FMT
                     " = " TLOG_TIMESPEC_FMT " != " TLOG_TIMESPEC_FMT "\n",
+                    file, line,
                     TLOG_TIMESPEC_ARG(&a), op_list[i].sym,
                     TLOG_TIMESPEC_ARG(&b),
                     TLOG_TIMESPEC_ARG(&res), TLOG_TIMESPEC_ARG(&exp_res));
@@ -99,9 +102,10 @@ main(void)
 #define TS(_sec, _nsec) (struct timespec){_sec, _nsec}
 
 #define TEST(_op_list, _a, _b, _exp_res) \
-    do {                                                                \
-        passed = op_list_test((_op_list), TLOG_ARRAY_SIZE(_op_list),    \
-                              _a, _b, _exp_res) && passed;              \
+    do {                                                      \
+        passed = op_list_test(__FILE__, __LINE__, (_op_list), \
+                              TLOG_ARRAY_SIZE(_op_list),      \
+                              _a, _b, _exp_res) && passed;    \
     } while (0)
 
     /*

--- a/src/tlog-test-timestr.c
+++ b/src/tlog-test-timestr.c
@@ -25,7 +25,8 @@
 #include <stdio.h>
 
 bool
-test(const char *timestr, bool exp_rc, struct timespec exp_ts)
+test(const char *file, int line, const char *timestr,
+     bool exp_rc, struct timespec exp_ts)
 {
     bool passed;
     bool rc_passed;
@@ -40,14 +41,16 @@ test(const char *timestr, bool exp_rc, struct timespec exp_ts)
 
     if (passed) {
         fprintf(stderr,
-                "PASS: tlog_timestr_to_timespec(\"%s\", "
+                "PASS %s:%d tlog_timestr_to_timespec(\"%s\", "
                 TLOG_TIMESPEC_FMT ") = %s\n",
+                file, line,
                 timestr, TLOG_TIMESPEC_ARG(&ts), (rc ? "true" : "false"));
     } else {
         fprintf(stderr,
-                "FAIL: tlog_timestr_to_timespec(\"%s\", "
+                "FAIL %s:%d tlog_timestr_to_timespec(\"%s\", "
                 TLOG_TIMESPEC_FMT " %s " TLOG_TIMESPEC_FMT") = "
                 "%s %s %s\n",
+                file, line,
                 timestr, TLOG_TIMESPEC_ARG(&ts), (ts_passed ? "==" : "!="),
                 TLOG_TIMESPEC_ARG(&exp_ts),
                 (rc ? "true" : "false"), (rc_passed ? "==" : "!="),
@@ -64,7 +67,7 @@ main(void)
 
 #define TS(_sec, _nsec) (struct timespec){_sec, _nsec}
 #define TEST(_timestr, _exp_rc, _exp_ts) \
-    passed = test(_timestr, _exp_rc, _exp_ts) && passed;
+    passed = test(__FILE__, __LINE__, _timestr, _exp_rc, _exp_ts) && passed;
 
     TEST("A", false, TS(0, 0));
     TEST(",", false, TS(0, 0));


### PR DESCRIPTION
Hi Nick, I add the line, and function name to tlog-test-timespec.c to provide information for debug. Can you look at it? If it is fine, I will modify the rest of test C file. Because I want to know exact line of test case that makes the code error, I add __LINE__ as a parameter in function op_list_test(....). I am not sure it is a good way or not. If you know a better way to do this, please let me know. I give the image modify the test case (116-119 and 124-127).  I also want to list exact operation function pointer that makes wrong case, but I do not know how to find the good way. In my code it only reports op_list_test function. 
![debug](https://user-images.githubusercontent.com/10912671/33464105-8846eb40-d5f5-11e7-9f03-d0fcdbf14bad.jpg)
