### PR TITLE
Implement error handling macros

### DIFF
--- a/include/tlog/errs.h
+++ b/include/tlog/errs.h
@@ -141,4 +141,64 @@ extern void tlog_errs_pushf(struct tlog_errs **perrs, const char *fmt, ...)
  */
 extern int tlog_errs_print(FILE *stream, const struct tlog_errs *errs);
 
+/**
+ * Push an error to the "perrs" stack, with message as a constant string
+ * and then go to cleanup.
+ *
+ * @param _msg   The message string to copy and put into the pushed error.
+ *               Cannot be NULL.
+ */
+#define TLOG_ERRS_RAISES(_msg) \
+     do {                                                                 \
+         tlog_errs_pushs(perrs, _msg);                                    \
+         goto cleanup;                                                    \
+     } while (0)
+
+/**
+ * Push two errors to the "perrs" stack, first one with message being a global
+ * return code description, and the second with message as a constant string.
+ * And then go to cleanup.
+ *
+ * @param _grc  The global return code, which description will be pushed to
+ *              the stack.
+ * @param _msg  The message string to copy and put into the pushed error.
+ *              Cannot be NULL.
+ */
+#define TLOG_ERRS_RAISECS(_grc, _msg) \
+     do {                                                                 \
+         tlog_errs_pushc(perrs, _grc);                                    \
+         tlog_errs_pushs(perrs, _msg);                                    \
+         goto cleanup;                                                    \
+     } while (0)
+
+/**
+ * Push an error to the "perrs" stack, with a sprintf-formatted message.
+ * And then go to cleanup.
+ *
+ * @param _fmt  The message sprintf(3) format string. Cannot be NULL.
+ * @param ...   The message format arguments.
+ */
+#define TLOG_ERRS_RAISEF(_fmt, _args...) \
+     do {                                                                 \
+         tlog_errs_pushf(perrs, _fmt, ##_args);                           \
+         goto cleanup;                                                    \
+     } while (0)
+
+/**
+ * Push two errors to the "perrs" stack, first one with message being a global
+ * return code description, and the second with a sprintf-formatted message.
+ * And then go to cleanup.
+ *
+ * @param _grc  The global return code, which description will be pushed to
+ *              the stack.
+ * @param _fmt  The message sprintf(3) format string. Cannot be NULL.
+ * @param ...   The message format arguments.
+ */
+#define TLOG_ERRS_RAISECF(_grc, _fmt, _args...) \
+     do {                                                                 \
+         tlog_errs_pushc(perrs, _grc);                                    \
+         tlog_errs_pushf(perrs, _fmt, ##_args);                           \
+         goto cleanup;                                                    \
+     } while (0)
+
 #endif /* _TLOG_ERRS_H */

--- a/lib/tlog/misc.c
+++ b/lib/tlog/misc.c
@@ -138,17 +138,13 @@ tlog_exec(struct tlog_errs **perrs, unsigned int opts,
         /* Drop the possibly-privileged EGID permanently */
         if (setresgid(gid, gid, gid) < 0) {
             grc = TLOG_GRC_ERRNO;
-            tlog_errs_pushc(perrs, grc);
-            tlog_errs_pushf(perrs, "Failed dropping EGID");
-            goto cleanup;
+            TLOG_ERRS_RAISECF(grc, "Failed dropping EGID");
         }
 
         /* Drop the possibly-privileged EUID permanently */
         if (setresuid(uid, uid, uid) < 0) {
             grc = TLOG_GRC_ERRNO;
-            tlog_errs_pushc(perrs, grc);
-            tlog_errs_pushf(perrs, "Failed dropping EUID");
-            goto cleanup;
+            TLOG_ERRS_RAISECF(grc, "Failed dropping EUID");
         }
     }
 

--- a/lib/tlog/play_conf.c
+++ b/lib/tlog/play_conf.c
@@ -44,16 +44,13 @@ tlog_play_conf_file_load(struct tlog_errs **perrs,
     /* Load the file */
     grc = tlog_json_object_from_file(&conf, path);
     if (grc != TLOG_RC_OK) {
-        tlog_errs_pushc(perrs, grc);
-        tlog_errs_pushf(perrs, "Failed loading \"%s\"", path);
-        goto cleanup;
+        TLOG_ERRS_RAISECF(grc, "Failed loading \"%s\"", path);
     }
 
     /* Validate the contents */
     grc = tlog_play_conf_validate(perrs, conf, TLOG_CONF_ORIGIN_FILE);
     if (grc != TLOG_RC_OK) {
-        tlog_errs_pushf(perrs, "Invalid contents of \"%s\"", path);
-        goto cleanup;
+        TLOG_ERRS_RAISEF("Invalid contents of \"%s\"", path);
     }
 
     *pconf = conf;
@@ -83,9 +80,7 @@ tlog_play_conf_load(struct tlog_errs **perrs,
     conf = json_object_new_object();
     if (conf == NULL) {
         grc = TLOG_GRC_ERRNO;
-        tlog_errs_pushc(perrs, grc);
-        tlog_errs_pushs(perrs, "Failed creating configuration object");
-        goto cleanup;
+        TLOG_ERRS_RAISECS(grc, "Failed creating configuration object");
     }
 
     /* Overlay with default config */
@@ -93,22 +88,17 @@ tlog_play_conf_load(struct tlog_errs **perrs,
                                   TLOG_PLAY_CONF_DEFAULT_BUILD_PATH,
                                   TLOG_PLAY_CONF_DEFAULT_INST_PATH);
     if (grc != TLOG_RC_OK) {
-        tlog_errs_pushc(perrs, grc);
-        tlog_errs_pushs(perrs, "Failed finding default configuration");
-        goto cleanup;
+        TLOG_ERRS_RAISECS(grc, "Failed finding default configuration");
     }
     grc = tlog_play_conf_file_load(perrs, &overlay, path);
     if (grc != TLOG_RC_OK) {
-        tlog_errs_pushs(perrs, "Failed loading default configuration");
-        goto cleanup;
+        TLOG_ERRS_RAISES("Failed loading default configuration");
     }
     free(path);
     path = NULL;
     grc = tlog_json_overlay(&conf, conf, overlay);
     if (grc != TLOG_RC_OK) {
-        tlog_errs_pushc(perrs, grc);
-        tlog_errs_pushs(perrs, "Failed overlaying default configuration");
-        goto cleanup;
+        TLOG_ERRS_RAISECS(grc, "Failed overlaying default configuration");
     }
     json_object_put(overlay);
     overlay = NULL;
@@ -118,22 +108,17 @@ tlog_play_conf_load(struct tlog_errs **perrs,
                                   TLOG_PLAY_CONF_LOCAL_BUILD_PATH,
                                   TLOG_PLAY_CONF_LOCAL_INST_PATH);
     if (grc != TLOG_RC_OK) {
-        tlog_errs_pushc(perrs, grc);
-        tlog_errs_pushs(perrs, "Failed finding system configuration");
-        goto cleanup;
+        TLOG_ERRS_RAISECS(grc, "Failed finding system configuration");
     }
     grc = tlog_play_conf_file_load(perrs, &overlay, path);
     if (grc != TLOG_RC_OK) {
-        tlog_errs_pushs(perrs, "Failed loading system configuration");
-        goto cleanup;
+        TLOG_ERRS_RAISES("Failed loading system configuration");
     }
     free(path);
     path = NULL;
     grc = tlog_json_overlay(&conf, conf, overlay);
     if (grc != TLOG_RC_OK) {
-        tlog_errs_pushc(perrs, grc);
-        tlog_errs_pushs(perrs, "Failed overlaying system configuration");
-        goto cleanup;
+        TLOG_ERRS_RAISECS(grc, "Failed overlaying system configuration");
     }
     json_object_put(overlay);
     overlay = NULL;
@@ -141,16 +126,12 @@ tlog_play_conf_load(struct tlog_errs **perrs,
     /* Overlay with command-line config */
     grc = tlog_play_conf_cmd_load(perrs, &cmd_help, &overlay, argc, argv);
     if (grc != TLOG_RC_OK) {
-        tlog_errs_pushs(perrs,
-                        "Failed retrieving configuration from command line");
-        goto cleanup;
+        TLOG_ERRS_RAISES("Failed retrieving configuration from command line");
     }
     grc = tlog_json_overlay(&conf, conf, overlay);
     if (grc != TLOG_RC_OK) {
-        tlog_errs_pushc(perrs, grc);
-        tlog_errs_pushs(perrs,
-                        "Failed overlaying command-line configuration");
-        goto cleanup;
+        TLOG_ERRS_RAISECS(grc,
+                          "Failed overlaying command-line configuration");
     }
     json_object_put(overlay);
     overlay = NULL;

--- a/src/tlog/tlog-play.c
+++ b/src/tlog/tlog-play.c
@@ -34,6 +34,7 @@ main(int argc, char **argv)
 {
     tlog_grc grc;
     struct tlog_errs *errs = NULL;
+    struct tlog_errs **perrs = &errs;
     struct json_object *conf = NULL;
     char *cmd_help = NULL;
     const char *charset;
@@ -42,10 +43,8 @@ main(int argc, char **argv)
     /* Set locale from environment variables */
     if (setlocale(LC_ALL, "") == NULL) {
         grc = TLOG_GRC_ERRNO;
-        tlog_errs_pushc(&errs, grc);
-        tlog_errs_pushs(&errs,
-                        "Failed setting locale from environment variables");
-        goto cleanup;
+        TLOG_ERRS_RAISECS(grc, "Failed setting locale from "
+                          "environment variables");
     }
 
     /* Read configuration and command-line usage message */
@@ -63,8 +62,7 @@ main(int argc, char **argv)
                                    "and charset is UTF-8");
         } else {
             grc = TLOG_RC_FAILURE;
-            tlog_errs_pushf(&errs, "Unsupported locale charset: %s", charset);
-            goto cleanup;
+            TLOG_ERRS_RAISEF("Unsupported locale charset: %s", charset);
         }
     }
 


### PR DESCRIPTION
Fixes #116 
I send the first draft. As I said before, I implement error handling macros based on 4 types that you use. I feel it is not good idea to do that. Could you give some advice? 

> For type 1: 

```
        if (!json_object_object_get_ex(conf, "file", &conf_file)) {
            tlog_errs_pushs(perrs,
                            "File reader parameters are not specified");
            grc = TLOG_RC_FAILURE;
            goto cleanup;
        }
```
--> It becomes: 
```
        if (!json_object_object_get_ex(conf, "file", &conf_file)) {
            grc = tlog_handler1(perrs, TLOG_RC_FAILURE, "File reader parameters are not specified");
            goto cleanup;
        }
```

> For type 3: 

```
    if (setlocale(LC_ALL, "") == NULL) {
        grc = TLOG_GRC_ERRNO;
        tlog_errs_pushc(&errs, grc);
        tlog_errs_pushs(&errs,
                        "Failed setting locale from environment variables");
        goto cleanup;
    }
```
---> It becomes: 

```
    if (setlocale(LC_ALL, "") == NULL) {
        grc = tlog_handler3(&errs, TLOG_GRC_ERRNO, "Failed Setting locale from environment variables")
        goto cleanup;
    }
```
I do not finish function relating `pushf` because of its complex argument, and I wait for your thought about implementation. Do you implement all these situation in a function? 