### PR TITLE
Do not exit tlog-play with "-g end -p" options

### DIFF
--- a/lib/tlog/play.c
+++ b/lib/tlog/play.c
@@ -927,6 +927,8 @@ tlog_play_run(struct tlog_errs **perrs, int *psignal)
                 if (tlog_play_follow) {
                     read_wait = (struct timespec){POLL_PERIOD, 0};
                     continue;
+                } else if (tlog_play_paused) {
+                    continue;
                 } else {
                     break;
                 }


### PR DESCRIPTION
Hi Nick, pull request for this issue: https://github.com/Scribery/tlog/issues/150. 
I handle the issue 150 without using more variable. Executing `--goto=10 -p` is the same `--goto=END -p`. It does not exit after going to end. Instead it should stay on pause.
I realize that I do not follow your style coding ( open braces) in the first commit. I modified it too.  
Sorry, I do not know why my commit go along with your commit's refactor 