### PR TITLE
Implement tlog-play "to" function

### DIFF
--- a/m4/tlog/play_conf_schema.m4
+++ b/m4/tlog/play_conf_schema.m4
@@ -45,6 +45,14 @@ M4_PARAM(`', `goto', `opts-',
                    `Can be a "start", or an "end" string, or a timestamp formatted as',
                    `HH:MM:SS.sss, where any part can be omitted to mean zero.')')m4_dnl
 m4_dnl
+M4_PARAM(`', `to', `opts-',
+         `M4_TYPE_STRING()', false,
+         `t', `=STRING', `Stop to STRING time (start/end/HH:MM:SS.sss)',
+         `STRING is a ', `A ',
+         `M4_LINES(`logical location, or a time to which recording should be stopped at specific time.',
+         `Can be a "start", or an "end" string, or a timestamp formatted as',
+         `HH:MM:SS.sss, where any part can be omitted to mean zero.')')m4_dnl
+m4_dnl
 M4_PARAM(`', `paused', `opts-',
          `M4_TYPE_BOOL(false)', true,
          `p', `', `Start playback paused',


### PR DESCRIPTION
As we know, the function `"goto"` is the fast-forward to STRING time. Tlog-play will play recording from the STRING time that we set until to the end. I implemented the `"to"` function that Tlog-play will `STOP` at STRING time. I think it is convenient because : 
1) Sometimes, users do not want to play recording until the END. They want to stop at specific time. For example: 
`tlog-play -i clock.log --to=10` .
 It will play recording from `START` to `10` and exit. 

2) For cooperate with `"goto"` function. Usually, the recording is too long, and the users want to focus on the specific range time. They can fast-forward to specific time and then play the recording until hitting the specific time. For instance: 
`tlog-play -i clock.log --goto=150 --to=200`
It will play recording from 150 - 200 ( the specific range time)

I modified `play_conf_schema.m4` to generate the play_conf_cmd.c with one more option "to". In `play.c` I declare 2 variable ( one variable for storing the timestamp and one for flag). What do you think?