### PR TITLE
Add localstatedir=/var to configure option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ generate the build system files:
 After that, or if you're building a [release source tarball][releases], you
 need to follow the usual configure & make approach:
 
-    ./configure --prefix=/usr --sysconfdir=/etc && make
+    ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var && make
 
 To generate a source tarball:
 


### PR DESCRIPTION
Pull request for issue #182 ,
As you mention, it is good to add `localstatedir=/var` to configure option. It resolve the lock file issue. 
![fix_lock_file](https://user-images.githubusercontent.com/10912671/37622318-9068de44-2b7e-11e8-9e4f-99348f353b5c.JPG)
