### PR TITLE
Added BuildDependencies to allow yum-builddep

### DIFF
--- a/tlog.spec
+++ b/tlog.spec
@@ -8,13 +8,16 @@ License:    GPLv2+
 URL:        https://github.com/Scribery/%{name}
 Source:     https://github.com/Scribery/%{name}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
-BuildRequires:  json-c-devel
-BuildRequires:  curl-devel
-BuildRequires:  m4
+BuildRequires: json-c-devel
+BuildRequires: curl-devel
+BuildRequires: m4
+BuildRequires: libtool
 # If it's not RHEL6 and older
 %if 0%{?rhel} == 0 || 0%{?rhel} >= 7
-BuildRequires:  systemd-devel
-BuildRequires:  systemd-units
+BuildRequires: systemd-devel
+BuildRequires: systemd-units
+BuildRequires: autoconf
+BuildRequires: automake
 %endif
 Requires(post):     sed
 Requires(postun):   sed


### PR DESCRIPTION
On a minimal system, the existing dependencies do not provide enough
information to fully build tlog from source.

Adding a few items allows us to use `yum-builddep` and install all
required dependencies for both EL6 and EL7 systems.

Fixes #199