### PR TITLE
Modify comma placement in tlog configuration files

### DIFF
--- a/m4/tlog/conf_misc.m4
+++ b/m4/tlog/conf_misc.m4
@@ -57,12 +57,14 @@ m4_define(
 `m4_pushdef(`M4_CONF_CONTAINER_SIZE_VAL', `0')m4_dnl
 m4_pushdef(`M4_CONTAINER', `')m4_dnl
 m4_pushdef(`M4_PARAM', m4_defn(`_M4_CONF_CONTAINER_SIZE_ADD_PARAM'))m4_dnl
+m4_pushdef(`M4_PARAM_LAST_FIELD', m4_defn(`_M4_CONF_CONTAINER_SIZE_ADD_PARAM'))m4_dnl
 m4_pushdef(`M4_CONF_PREFIX', `$2')m4_dnl
 m4_pushdef(`M4_CONF_ORIGIN', `$3')m4_dnl
 m4_include(`$1')m4_dnl
 m4_popdef(`M4_CONF_ORIGIN')m4_dnl
 m4_popdef(`M4_CONF_PREFIX')m4_dnl
 m4_popdef(`M4_PARAM')m4_dnl
+m4_popdef(`M4_PARAM_LAST_FIELD')m4_dnl
 m4_popdef(`M4_CONTAINER')m4_dnl
 M4_CONF_CONTAINER_SIZE_VAL()m4_dnl
 m4_popdef(`M4_CONF_CONTAINER_SIZE_VAL')'m4_dnl

--- a/m4/tlog/play_conf_schema.m4
+++ b/m4/tlog/play_conf_schema.m4
@@ -86,7 +86,7 @@ M4_PARAM(`/es', `baseurl', `file-',
          `M4_LINES(`base URL to request Elasticsearch through. Should not',
                    `contain query (?...) or fragment (#...) parts.')')m4_dnl
 m4_dnl
-M4_PARAM(`/es', `query', `file-',
+M4_PARAM_LAST_FIELD(`/es', `query', `file-',
          `M4_TYPE_STRING()', false,
          `', `=STRING', `Elasticsearch query',
          `STRING is the ', `The ',

--- a/m4/tlog/rec_common_conf_schema.m4
+++ b/m4/tlog/rec_common_conf_schema.m4
@@ -57,7 +57,7 @@ _M4_PARAM(`/log', `output', `file-',
           `If specified as ', `If ',
           `M4_LINES(`true, terminal output is logged.')')m4_dnl
 m4_dnl
-_M4_PARAM(`/log', `window', `file-',
+_M4_PARAM_LAST_FIELD(`/log', `window', `file-',
           `M4_TYPE_BOOL(true)', true,
           `', `[=BOOL]', `Enable/disable logging terminal window size changes',
           `If specified as ', `If ',
@@ -80,7 +80,7 @@ _M4_PARAM(`/limit', `burst', `file-',
           `M4_LINES(`number of bytes by which logged messages are allowed to exceed',
                     `the rate limit momentarily, i.e. "burstiness".')')m4_dnl
 m4_dnl
-_M4_PARAM(`/limit', `action', `file-',
+_M4_PARAM_LAST_FIELD(`/limit', `action', `file-',
           `M4_TYPE_CHOICE(`pass', `pass', `delay', `drop')', true,
           `', `=STRING', `Perform STRING action above limits (pass/delay/drop)',
           `STRING is the ', `The ',
@@ -130,7 +130,7 @@ _M4_PARAM(`/syslog', `facility', `file-',
           `STRING is the ', `The ',
           `M4_LINES(`syslog facility "syslog" writer should use for messages.')')m4_dnl
 m4_dnl
-_M4_PARAM(`/syslog', `priority', `file-',
+_M4_PARAM_LAST_FIELD(`/syslog', `priority', `file-',
           `M4_TYPE_CHOICE(`info',
                           `emerg',
                           `alert',
@@ -166,7 +166,7 @@ _M4_PARAM(`/journal', `priority', `file-',
           `STRING is the ', `The ',
           `M4_LINES(`syslog-style priority "journal" writer should use for messages.')')m4_dnl
 m4_dnl
-_M4_PARAM(`/journal', `augment', `file-',
+_M4_PARAM_LAST_FIELD(`/journal', `augment', `file-',
           `M4_TYPE_BOOL(true)',
           true,
           `', `[=BOOL]', `Enable/disable adding extra journal fields',

--- a/m4/tlog/rec_conf_schema.m4
+++ b/m4/tlog/rec_conf_schema.m4
@@ -23,18 +23,20 @@ m4_dnl Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  US
 m4_dnl
 m4_include(`conf_schema.m4')m4_dnl
 m4_dnl
+m4_pushdef(`_M4_PARAM_LAST_FIELD', `M4_PARAM_LAST_FIELD($@)')m4_dnl
 m4_pushdef(`_M4_PARAM', `M4_PARAM($@)')m4_dnl
 m4_include(`rec_common_conf_schema.m4')m4_dnl
+m4_popdef(`_M4_PARAM_LAST_FIELD')m4_dnl
 m4_popdef(`_M4_PARAM')m4_dnl
 m4_dnl
 m4_ifelse(M4_JOURNAL_ENABLED(), `1',
-`M4_PARAM(`', `writer', `file-',
+`M4_PARAM_LAST_FIELD(`', `writer', `file-',
           `M4_TYPE_CHOICE(`file', `journal', `syslog', `file')', true,
           `w', `=STRING', `Use STRING log writer (journal/syslog/file, default file)',
           `STRING is the ', `The ',
           `M4_LINES(`type of "log writer" to use for logging. The writer needs',
                     `to be configured using its dedicated parameters.')')',
-`M4_PARAM(`', `writer', `file-',
+`M4_PARAM_LAST_FIELD(`', `writer', `file-',
           `M4_TYPE_CHOICE(`file', `syslog', `file')', true,
           `w', `=STRING', `Use STRING log writer (syslog/file, default file)',
           `STRING is the ', `The ',

--- a/m4/tlog/rec_session_conf_schema.m4
+++ b/m4/tlog/rec_session_conf_schema.m4
@@ -58,8 +58,10 @@ m4_dnl
 m4_dnl
 m4_dnl Include common schema, but limit its scope to environment
 m4_dnl
+m4_pushdef(`_M4_PARAM_LAST_FIELD', `M4_PARAM_LAST_FIELD(`$1', `$2', `$3env', m4_shiftn(3, $@))')m4_dnl
 m4_pushdef(`_M4_PARAM', `M4_PARAM(`$1', `$2', `$3env', m4_shiftn(3, $@))')m4_dnl
 m4_include(`rec_common_conf_schema.m4')m4_dnl
+m4_popdef(`_M4_PARAM_LAST_FIELD')m4_dnl
 m4_popdef(`_M4_PARAM')m4_dnl
 m4_dnl
 m4_ifelse(M4_JOURNAL_ENABLED(), `1',

--- a/src/tlog/tlog-prog.conf.m4
+++ b/src/tlog/tlog-prog.conf.m4
@@ -58,6 +58,15 @@ m4_define(
 )
 
 m4_define(
+    `M4_PARAM_LAST_FIELD',
+    `
+        m4_pushdef(`M4_APPEND_COMMA', `false')
+        M4_PARAM($@)
+        m4_popdef(`M4_APPEND_COMMA')
+    '
+)
+
+m4_define(
     `M4_PARAM',
     `
         m4_ifelse(

--- a/src/tlog/tlog-prog.conf.m4
+++ b/src/tlog/tlog-prog.conf.m4
@@ -11,6 +11,7 @@ m4_divert(-1)
 m4_define(`M4_PREFIX', `')
 m4_define(`M4_INDENT', `')
 m4_define(`M4_FIRST', `true')
+m4_define(`M4_APPEND_COMMA', `true')
 
 m4_define(
     `M4_TYPE_INT',
@@ -71,7 +72,8 @@ m4_define(
                             M4_FIRST(),
                             `true',
                             `m4_define(`M4_FIRST', `false')',
-                            `m4_printl(`,', `')'
+                            `m4_printl(`')'
+                            `m4_printl(`')'
                         )
                         m4_print(M4_INDENT()`// m4_argn(`10', $@)')
                         m4_argn(`11', $@)
@@ -85,6 +87,11 @@ m4_define(
                             `m4_print(`// ')'
                         )
                         m4_print(`"$2" : ')$4
+                        m4_ifelse(
+                            M4_APPEND_COMMA(),
+                            `true',
+                            `m4_print(`,')',
+                        )
                     '
                 )
             '
@@ -110,7 +117,8 @@ m4_define(
                             M4_FIRST(),
                             `true',
                             `m4_define(`M4_FIRST', `false')',
-                            `m4_printl(`,', `')'
+                            `m4_printl(`')'
+                            `m4_printl(`')'
                         )
                         m4_ifelse(
                             `$2',


### PR DESCRIPTION
This PR is intended to modify the comma character placement in the default generated configuration files.

To allow successful front-end JSON parsing of configuration files, remove the trailing comma from container blocks, such as:

```
   // Journal writer parameters
    "journal": {
        // The syslog-style priority "journal" writer should use for messages.
        // "priority" : "info",

        // If true, the "journal" writer copies the following JSON fields
        // to Journal fields: user -> TLOG_USER, session -> TLOG_SESSION,
        // rec -> TLOG_REC, and id -> TLOG_ID.
        // "augment" : true
    },

```

Add and utilize the M4_PARAM_LAST_FIELD macro in certain situations where no trailing comma is needed.

This modifies the tlog-rec and tlog-rec-session configuration files, but the PR is still a work in progress as it creates an empty container in the m4 generated tlog-play.conf files.
```

     // Systemd journal reader parameters                                                                                                                                                                        
     "journal": {                                                                                                                                                                                                
                                                                                                                                                                                                                 
     }        
```
I believe that when M4_CONTAINER(`', `/journal', `Systemd journal reader') is expanded the `M4_CONF_CONTAINER_SIZE` macro is returning != 0 and that is why the empty container gets created but I have not been able to determine the root cause.
