### PR TITLE
Add BuildDependencies to allow yum-builddep

### DIFF
--- a/tlog.spec
+++ b/tlog.spec
@@ -8,6 +8,9 @@ License:    GPLv2+
 URL:        https://github.com/Scribery/%{name}
 Source:     https://github.com/Scribery/%{name}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  libtool
 BuildRequires:  json-c-devel
 BuildRequires:  curl-devel
 BuildRequires:  m4


### PR DESCRIPTION
A cleanup of #200 by @trevor-vaughan.

On a minimal system, the existing dependencies do not provide enough
information to fully build tlog from source.

Adding a few items allows us to use `yum-builddep` and install all
required dependencies for both EL6 and EL7 systems.

Fixes #199