### PR TITLE
Command option parsing and --configuration option

### DIFF
--- a/lib/tlog/play.c
+++ b/lib/tlog/play.c
@@ -1187,6 +1187,23 @@ tlog_play(struct tlog_errs **perrs,
         }
     }
 
+    /* Check for the configuration flag */
+    if (json_object_object_get_ex(conf, "configuration", &obj)) {
+        if (json_object_get_boolean(obj)) {
+            const char *str;
+            str = json_object_to_json_string_ext(conf,
+                                                 JSON_C_TO_STRING_PRETTY);
+            if (str == NULL) {
+                grc = TLOG_GRC_ERRNO;
+                TLOG_ERRS_RAISECS(grc,
+                                  "Failed formatting configuration JSON");
+            }
+            printf("%s\n", str);
+            grc = TLOG_RC_OK;
+            goto cleanup;
+        }
+    }
+
     /* Output and discard any accumulated non-critical error messages */
     tlog_errs_print(stderr, *perrs);
     tlog_errs_destroy(perrs);

--- a/lib/tlog/rec.c
+++ b/lib/tlog/rec.c
@@ -1107,6 +1107,23 @@ tlog_rec(struct tlog_errs **perrs, uid_t euid, gid_t egid,
         }
     }
 
+    /* Check for the configuration flag */
+    if (json_object_object_get_ex(conf, "configuration", &obj)) {
+        if (json_object_get_boolean(obj)) {
+            const char *str;
+            str = json_object_to_json_string_ext(conf,
+                                                 JSON_C_TO_STRING_PRETTY);
+            if (str == NULL) {
+                grc = TLOG_GRC_ERRNO;
+                TLOG_ERRS_RAISECS(grc,
+                                  "Failed formatting configuration JSON");
+            }
+            printf("%s\n", str);
+            grc = TLOG_RC_OK;
+            goto cleanup;
+        }
+    }
+
     /*
      * Choose the clock: try to use coarse monotonic clock (which is faster),
      * if it provides the required resolution.

--- a/m4/tlog/conf_cmd.m4
+++ b/m4/tlog/conf_cmd.m4
@@ -529,7 +529,7 @@ m4_define(
            `',
            `    /* Description of short options */')
         m4_print(
-           `    static const char *shortopts = ":')
+           `    static const char *shortopts = "+:')
         M4_CONF_CMD_SHORTOPTS()
         m4_printl(
            `";',

--- a/m4/tlog/conf_schema.m4
+++ b/m4/tlog/conf_schema.m4
@@ -96,3 +96,9 @@ M4_PARAM(`', `version', `opts',
          `v', `', `Output version information and exit',
          `', `',
          `M4_LINES(`')')m4_dnl
+m4_dnl
+M4_PARAM(`', `configuration', `opts',
+         `M4_TYPE_BOOL(false)', true,
+         `', `', `Output program configuration in JSON and exit',
+         `', `',
+         `M4_LINES(`')')m4_dnl


### PR DESCRIPTION
This switches command-line option parsing to stop looking for options after the first non-option argument, and adds the "--configuration" option.

This supersedes #213.