### PR TITLE
CI: Fix coverage analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ script:
 - rpmbuild --define "_tmpfilesdir /usr/lib/tmpfiles.d" -ta --nodeps tlog-*.tar.gz
 - test "x$DISTCHECK" = xyes && make distcheck || true
 after_success:
-- test "x$COVERAGE" = xyes -a "x$CC" = "xgcc" && lcov --compat-libtool --directory . --capture --output-file coverage.info && coveralls-lcov coverage.info
+- test "x$COVERAGE" = xyes -a "x$CC" = "xgcc" && lcov --compat-libtool --directory ./lib/tlog/ --capture --output-file coverage.info && coveralls-lcov coverage.info


### PR DESCRIPTION
This PR should fix some issues with coverage analysis evident on https://coveralls.io/github/Scribery/tlog

Execute `src/tlog/tlog-{play,rec,rec-session}` programs in Travis CI, this is required
to generate gcda files to include **src/tlog/*.c** files in coverage reports.

Exclude unneeded subdirectories from coverage analysis.