### PR TITLE
Log more detailed error when systemd journal is not present

### DIFF
--- a/lib/tlog/rec.c
+++ b/lib/tlog/rec.c
@@ -951,8 +951,13 @@ tlog_rec_transfer(struct tlog_errs    **perrs,
     /* Flush the log */
     grc = tlog_sink_flush(log_sink);
     if (grc != TLOG_RC_OK) {
-        tlog_errs_pushc(perrs, grc);
-        tlog_errs_pushs(perrs, "Failed flushing the log");
+        if (grc == (TLOG_GRC_FROM(systemd, -ENOENT))) {
+            tlog_errs_pushc(perrs, grc);
+            tlog_errs_pushs(perrs, "Systemd journal not available or not responsive");
+        } else {
+            tlog_errs_pushc(perrs, grc);
+            tlog_errs_pushs(perrs, "Failed flushing the log");
+        }
         if (return_grc == TLOG_RC_OK) {
             return_grc = grc;
         }


### PR DESCRIPTION
On distributions where `systemd` is not installed(or `systemd-journal` is not available),
logging to the journal will inevitably fail. Improve the error message logged when
this occurs. This PR is created for Issue #222 

The resulting error message looks like:
```
No such file or directory
Systemd journal not available or responsive
Failed transferring TTY data
```

I expect there is a better way to handle this, please review :)