### PR TITLE
Add initial tlog integration test

### DIFF
--- a/lib/tlitest/test_tlog.py
+++ b/lib/tlitest/test_tlog.py
@@ -1,0 +1,129 @@
+""" tlog tests """
+
+import os
+import ast
+import stat
+import time
+import pytest
+import pexpect
+import inspect
+from pexpect import pxssh
+from systemd import journal
+from tempfile import mkdtemp
+
+
+def journal_find_last():
+    j = journal.Reader()
+    j.seek_tail()
+    entry = j.get_previous()
+    while('TLOG_REC' not in entry):
+        entry = j.get_previous()
+    return entry
+
+
+def check_journal(pattern):
+    time.sleep(1)
+    entry = journal_find_last()
+    message = entry['MESSAGE']
+    out_txt = ast.literal_eval(message)['out_txt']
+    if pattern in out_txt:
+        return 0
+    else:
+        return 1
+
+
+def check_outfile(pattern, filename):
+    time.sleep(1)
+    file1 = open(filename, 'r')
+    content = file1.read()
+    file1.close()
+    if pattern in content:
+        return 0
+    else:
+        return 1
+
+
+def check_recording(shell, pattern, filename=None):
+    time.sleep(1)
+    if filename is not None:
+        cmd = 'tlog-play -i {}'.format(filename)
+    else:
+        entry = journal_find_last()
+        message = entry['MESSAGE']
+        rec = ast.literal_eval(message)['rec']
+        tlog_rec = 'TLOG_REC={}'.format(rec)
+        cmd = 'tlog-play -r journal -M {}'.format(tlog_rec)
+    shell.sendline(cmd)
+    out = shell.expect([pexpect.TIMEOUT, pattern], timeout=10)
+    # print(shell.before)
+    # print(shell.after)
+    if out == 0:
+        print('\ncheck_recording TIMEOUT')
+    assert out == 1
+
+
+def ssh_pexpect(username, password, hostname, encoding='utf-8'):
+    s = pxssh.pxssh(options={
+                    "StrictHostKeyChecking": "no",
+                    "UserKnownHostsFile": "/dev/null"},
+                    encoding=encoding, codec_errors='replace')
+    s.force_password = True
+    s.login(hostname, username, password)
+    s.sendline('echo loggedin')
+    s.expect('loggedin')
+    # s.logfile = sys.stdout
+    return s
+
+
+def mklogfile(directory, filename=None):
+    # if filename not given, we use the name of the calling frame
+    if filename is None:
+        filename = '{}.tlog'.format(inspect.stack()[1][3])
+    logfile = '{}/{}'.format(directory, filename)
+    if not os.path.isdir(directory):
+        os.makedirs(directory)
+        os.chmod(tempdir, stat.S_IRWXU + stat.S_IRWXG + stat.S_IRWXO +
+                 stat.S_ISUID + stat.S_ISGID + stat.S_ISVTX)
+    return logfile
+
+
+class TestTlogRec(object):
+    tempdir = mkdtemp(prefix='/tmp/TestTlogRec.')
+    user1 = 'tlitestlocaluser1'
+    admin1 = 'tlitestlocaladmin1'
+    os.chmod(tempdir, stat.S_IRWXU + stat.S_IRWXG + stat.S_IRWXO +
+             stat.S_ISUID + stat.S_ISGID + stat.S_ISVTX)
+
+    def test_record_command_to_file(self):
+        """
+        As a user, record command output to a file
+        """
+        logfile = mklogfile(self.tempdir)
+        shell = ssh_pexpect(self.user1, 'Secret123', 'localhost')
+        shell.sendline('tlog-rec -o {} whoami'.format(logfile))
+        check_outfile('out_txt\":\"localuser1', logfile)
+        check_recording(shell, 'localuser1', logfile)
+        shell.close()
+
+    def test_record_command_to_journal(self):
+        """
+        As a user, record command output to the systemd journal
+        """
+        logfile = mklogfile(self.tempdir)
+        shell = ssh_pexpect(self.user1, 'Secret123', 'localhost')
+        reccmd = 'echo test_record_to_journal'
+        shell.sendline('tlog-rec -w journal {}'.format(reccmd))
+        check_journal('test_record_to_journal')
+        check_recording(shell, 'test_record_to_journal')
+        shell.close()
+
+    def test_record_command_to_syslog(self):
+        """
+        As a user, record command output to syslog
+        """
+        shell = ssh_pexpect(self.user1, 'Secret123', 'localhost')
+        reccmd = 'echo test_record_to_syslog'
+        shell.sendline('tlog-rec --writer=syslog {}'.format(reccmd))
+        check_journal('test_record_to_syslog')
+        check_recording(shell, 'test_record_to_syslog')
+        shell.close()

--- a/src/tlitest/README.md
+++ b/src/tlitest/README.md
@@ -1,0 +1,51 @@
+Tlog Integration Tests
+======================
+
+Tlog Integration Tests provide real world tests for various features
+and functionalities of tlog.  Although these tests are meant for
+OS package build gating, they can be run for general testing purposes
+as well.
+
+This README.md will provide information on how to prepare for, run,
+and cleanup after the tests.
+
+Setup
+-----
+
+In the src/tlitest directory, run the main setup script:
+    ./tlitest-setup
+
+This will install necessary packages, add users and setup a wheel
+based no password sudoer rule file.
+
+As a part of setup, we also take note of the specified packages that
+were already installed before setup.  This allows us to skip them
+during package removal of cleanup (teardown).
+
+Also, during setup, we take note of users the same way so that
+pre-existing users will skip delete during cleanup.
+
+Run
+---
+
+To run the tests, you must execute pytest.  In the src/tlitest
+directory run:
+    ./tlitest-run
+
+If you want to generate a junit xml file for upload for reporting,
+run:
+    ./tlitest-run --junit-xml=/tmp/path-to-your-junit-xml-file
+
+Cleanup
+-------
+
+The cleanup after the tests, inside the src/tlitest directory run:
+    ./tlitest-teardown
+
+This will look for pre-existing packages and skip them.  Packages
+installed by setup will be removed.
+
+This will also look for pre-existing users and skip them. Users
+added by setup will be removed.
+
+The sudoers rule file added by setup will also be removed.

--- a/src/tlitest/tlitest-run
+++ b/src/tlitest/tlitest-run
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pytest-3 -v "$(dirname $0)/../../lib/tlitest" "$@"

--- a/src/tlitest/tlitest-setup
+++ b/src/tlitest/tlitest-setup
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+PKGS="
+python3-pytest
+python3-pexpect
+python3-systemd
+tcsh
+tlog
+"
+PKGSFILE="/tmp/tlitest-setup_packages_found"
+if [ -f "$PKGSFILE" ]; then
+    echo "Backing up previous runs found packages file"
+    mv "$PKGSFILE" "$PKGSFILE.$(date +%Y-%m-%h_%H:%M:%S)"
+fi
+
+echo "Check and install packages to run tlog integration tests"
+for P in $PKGS; do
+    rpm -q "$P" > /dev/null
+    if [ $? -ne 0 ]; then
+        echo "RPM [$P] missing..installing"
+        dnf -y install $P
+    else
+        echo "RPM [$P] already installed...saving"
+        echo "$P" >> $PKGSFILE
+    fi
+done
+
+USERS="
+tlitestlocaluser1
+tlitestlocaladmin1
+"
+USERSFILE="/tmp/tlitest-setup_users_found"
+echo "Check and create users to run tlog integration tests"
+for U in $USERS; do
+    id "$U" > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "User [$U] missing...adding"
+        useradd -m "$U" -s /usr/bin/tlog-rec-session
+        echo -e "Secret123\nSecret123" |passwd "$U"
+    else
+        echo "User [$U] already exists...saving"
+        echo "$U" >> $USERSFILE
+    fi
+done
+
+echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > \
+    /etc/sudoers.d/01_wheel_nopass_tlitest

--- a/src/tlitest/tlitest-teardown
+++ b/src/tlitest/tlitest-teardown
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+PKGS="
+python3-pytest
+python3-pexpect
+python3-systemd
+tcsh
+tlog
+"
+PKGSFILE="/tmp/tlitest-setup_packages_found"
+echo "Check and remove packages from tlog integration tests"
+for P in $PKGS; do
+    if [ -f $PKGSFILE ]; then
+        if grep -q "$P" $PKGSFILE; then
+            echo "RPM [$P] found before tests..skipping remove"
+            continue
+        fi
+    fi
+    rpm -q "$P" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "RPM [$P] missing..installing"
+        dnf -y remove $P
+    fi
+done
+
+USERS="
+tlitestlocaluser1
+tlitestlocaladmin1
+"
+USERSFILE="/tmp/tlitest-setup_users_found"
+echo "Check and create users to run tlog integration tests"
+for U in $USERS; do
+    if [ -f $USERSFILE ]; then
+        if grep -q "$U" $USERSFILE; then
+            echo "User [$U] found before tests...skipping remove"
+            continue
+        fi
+    fi
+    id "$U" > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "User [$U] missing...adding"
+        useradd -m "$U" -s /usr/bin/tlog-rec-session
+        echo -e "Secret123\nSecret123" |passwd "$U"
+    fi
+done
+
+if [ -f /etc/sudoers.d/01_wheel_nopass_tlitest ]; then
+    echo "Found test sudoers file...removing"
+    rm /etc/sudoers.d/01_wheel_nopass_tlitest
+fi


### PR DESCRIPTION
This commit adds the first integration tests.  These tests are written
in python for pytest execution.  More specific information about how to
setup for the tests, run them, and cleanup afterwards is described in
the README.md file.

This commit provides:

* README.md -- descibes the tests and how to use them
* tlitest-setup -- script to setup dependencies like rpms and users
* tlitest-teardown -- script to cleanup after running the tests
* test_tlog.py -- the main pytest module for tlog integration tests