### PR TITLE
Add pycache and py[co] to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@
 *.la
 Makefile
 Makefile.in
+__pycache__/
+*.py[co]


### PR DESCRIPTION
Since the tlitest code uses pytest, we can potentially have additional
python files generated in source such as __pycache__/, *.pyc, or *.pyo
fiels.  We can ignore those from git.

Also, this was requested during review of PR #231.