### PR TITLE
journal_json_writer: Remove 'augment' boolean assertion

### DIFF
--- a/include/tlog/journal_json_writer.h
+++ b/include/tlog/journal_json_writer.h
@@ -68,9 +68,9 @@ tlog_journal_json_writer_create(struct tlog_json_writer **pwriter,
 {
     assert(pwriter != NULL);
     assert(tlog_syslog_priority_is_valid(priority));
-    assert(!augment || recording != NULL);
-    assert(!augment || username != NULL);
-    assert(!augment || session_id != 0);
+    assert(recording != NULL);
+    assert(username != NULL);
+    assert(session_id != 0);
     return tlog_json_writer_create(pwriter, &tlog_journal_json_writer_type,
                                    priority, augment,
                                    recording, username, session_id);

--- a/lib/tlog/journal_json_writer.c
+++ b/lib/tlog/journal_json_writer.c
@@ -57,9 +57,9 @@ tlog_journal_json_writer_init(struct tlog_json_writer *writer, va_list ap)
     unsigned int session_id = va_arg(ap, unsigned int);
 
     assert(tlog_syslog_priority_is_valid(priority));
-    assert(!augment || recording != NULL);
-    assert(!augment || username != NULL);
-    assert(!augment || session_id != 0);
+    assert(recording != NULL);
+    assert(username != NULL);
+    assert(session_id != 0);
 
     journal_json_writer->priority = priority;
 


### PR DESCRIPTION
Don't assert boolean value of `augment`, it is a configurable option
that could be true or false.

I believe if recording or username are NULL and we reach these assert lines,
then the assert won't trigger as expected.