### PR TITLE
man: Don't distribute tlog*.8 files

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -74,7 +74,7 @@ tlog-play.conf.5: tlog-play.conf.5.m4 $(TLOG_PLAY_CONF_DEPS)
 	   $< > $@ || \
 	{ rm $@ && false; }
 
-dist_man_MANS = \
+nodist_man_MANS = \
     tlog-play.8             \
     tlog-play.conf.5        \
     tlog-rec.8              \


### PR DESCRIPTION
Rules in `man/Makefile` do not execute when the `tlog*.8` targets already
exist.

This fixes an issue where **M4_CONF_PATH** does not expand to the correct
path when the `man/Makefile` rules are skipped.