### PR TITLE
Intg Tests: Poll Journal for Tier1 tests

### DIFF
--- a/lib/tlitest/journal.py
+++ b/lib/tlitest/journal.py
@@ -1,0 +1,26 @@
+import select
+import pexpect
+
+from systemd import journal
+
+def journal_event_poll(journal_reader, timeout):
+    p = select.poll()
+    p.register(journal_reader, journal_reader.get_events())
+    timeout_ms = timeout * 1000
+    ret = p.poll(timeout_ms)
+    if ret:
+        return journal_reader
+
+def find_journal_entry_with_match(pattern, match_filter, timeout):
+    reader = journal.Reader()
+    reader.this_boot()
+    reader.seek_tail()
+    reader.add_match(match_filter)
+
+    log_entry = journal_event_poll(reader, timeout)
+    if log_entry is None:
+        raise TimeoutError("No matching journal event found")
+    else:
+        for entry in log_entry:
+            message = entry['MESSAGE']
+            assert pattern in message

--- a/lib/tlitest/test_tlog_rec.py
+++ b/lib/tlitest/test_tlog_rec.py
@@ -10,6 +10,7 @@ import pexpect
 
 import pytest
 
+from journal import find_journal_entry_with_match
 from misc import check_recording, ssh_pexpect, mklogfile, \
                  check_outfile, check_journal, mkcfgfile, \
                  journal_find_last
@@ -41,10 +42,11 @@ class TestTlogRec:
         """
         Check tlog-rec preserves output when recording to journal
         """
+        match_filter = '_COMM=tlog-rec'
         shell = ssh_pexpect(self.user1, 'Secret123', 'localhost')
-        reccmd = 'echo test_record_to_journal'
-        shell.sendline('tlog-rec -w journal {}'.format(reccmd))
-        check_journal('test_record_to_journal')
+        reccmd = 'test_record_to_journal'
+        shell.sendline('tlog-rec -w journal echo {}'.format(reccmd))
+        find_journal_entry_with_match(reccmd, match_filter, 10)
         check_recording(shell, 'test_record_to_journal')
         shell.close()
 
@@ -53,10 +55,11 @@ class TestTlogRec:
         """
         Check tlog-rec preserves output when recording to syslog
         """
+        match_filter = '_COMM=tlog-rec'
         shell = ssh_pexpect(self.user1, 'Secret123', 'localhost')
-        reccmd = 'echo test_record_to_syslog'
-        shell.sendline('tlog-rec --writer=syslog {}'.format(reccmd))
-        check_journal('test_record_to_syslog')
+        reccmd = 'test_record_to_syslog'
+        shell.sendline('tlog-rec --writer=syslog echo {}'.format(reccmd))
+        find_journal_entry_with_match(reccmd, match_filter, 10)
         check_recording(shell, 'test_record_to_syslog')
         shell.close()
 


### PR DESCRIPTION
Polling the `systemd.journald` reader is more reliable and fixes some issues we see with timing/race journal failures in Gating.