### PR TITLE
Add -i/--interactive option to tlog-rec-session

### DIFF
--- a/m4/tlog/rec_session_conf_schema.m4
+++ b/m4/tlog/rec_session_conf_schema.m4
@@ -38,6 +38,12 @@ M4_PARAM(`', `login', `name-',
                    `This is done by prepending argv[0] of the shell',
                    `with a dash character.')')m4_dnl
 m4_dnl
+M4_PARAM(`', `interactive', `name-',
+         `M4_TYPE_BOOL()', false,
+         `i', `', `Make the shell an interactive shell',
+         `If specified, ', `If true ',
+         `M4_LINES(`tlog-rec-session passes the -i option to the shell.')')m4_dnl
+m4_dnl
 M4_PARAM(`', `command', `opts',
          `M4_TYPE_BOOL()', false,
          `c', `', `Execute shell commands',

--- a/man/tlog-rec-session.8.m4
+++ b/man/tlog-rec-session.8.m4
@@ -53,8 +53,8 @@ required and should contain shell commands to execute, the following
 arguments can specify first the script name (CMD_NAME, i.e. argv[0]) and then
 its arguments (CMD_ARG).
 
-If no non-option arguments are encountered, then the shell is started
-interactively.
+If no non-option arguments are encountered, or the "-i" option is specified
+then the shell is started interactively.
 
 If tlog-M4_PROG_NAME() is invoked under a name beginning with a dash (i.e.
 argv[0] beginning with '-'), then the executed shell name is also prepended


### PR DESCRIPTION
Shells such as **bash** and **tcsh** accept the `-i` option to start an interactive shell.

Pass the `-i` argument to the shell when **tlog-rec-session** is called with
the `-i` argument. This may be useful for applications/programs written
to execute shell programs with `-i`, such as Cockpit.