### PR TITLE
Fix spec file conditionals to build properly on EL6 and add missing BR for Debian/Ubuntu

### DIFF
--- a/tlog.spec
+++ b/tlog.spec
@@ -1,10 +1,10 @@
 %global _hardened_build 1
 
-%if 0%{?rhel} == 0 && 0%{?rhel} < 7
+%if 0%{?rhel} && 0%{?rhel} < 7
 # If it's RHEL6 and older
-%bcond_without systemd
-%else
 %bcond_with systemd
+%else
+%bcond_without systemd
 %endif
 
 %if %{_vendor} == "debbuild"
@@ -75,7 +75,7 @@ in JSON format.
 %setup -q
 
 %build
-%configure --disable-rpath --disable-static %{!?with systemd:--disable-journal}
+%configure --disable-rpath --disable-static %{!?with_systemd:--disable-journal}
 %make_build
 
 %check

--- a/tlog.spec
+++ b/tlog.spec
@@ -45,6 +45,8 @@ BuildRequires:  make
 %if %{_vendor} == "debbuild"
 BuildRequires:  libjson-c-dev
 BuildRequires:  libcurl4-gnutls-dev
+# Debian/Ubuntu doesn't automatically pull this in...
+BuildRequires:  pkg-config
 
 %if %{with systemd}
 BuildRequires:  libsystemd-dev


### PR DESCRIPTION
The conditions were accidentally set to force all distributions
to invoke the systemd dependencies, instead of allowing RHEL/CentOS 6
to not have systemd dependencies.

Also, add missing `BuildRequires: pkg-config` for Debian/Ubuntu builds.

Fixes #270 and #271.