### PR TITLE
Handle piped in I/O from STDIN

### DIFF
--- a/include/tlog/pkt.h
+++ b/include/tlog/pkt.h
@@ -158,6 +158,16 @@ extern void tlog_pkt_init_window(struct tlog_pkt *pkt,
                                  unsigned short int height);
 
 /**
+ * Initialize an I/O EOF packet.
+ *
+ * @param pkt       The packet to initialize.
+ * @param timestamp Timestamp of the EOF arrival.
+ * @param output    True if output originated I/O, false if input.
+ */
+extern void tlog_pkt_init_eof(struct tlog_pkt *pkt,
+                              const struct timespec *timestamp,
+                              bool output);
+/**
  * Initialize an I/O data packet.
  *
  * @param pkt       The packet to initialize.
@@ -191,6 +201,15 @@ extern bool tlog_pkt_is_valid(const struct tlog_pkt *pkt);
  * @return True if the packet is void, false otherwise.
  */
 extern bool tlog_pkt_is_void(const struct tlog_pkt *pkt);
+
+/**
+ * Check if a packet signalled an I/O EOF.
+ *
+ * @param pkt   The packet to check.
+ *
+ * @return True if the packet indicates EOF, false otherwise.
+ */
+extern bool tlog_pkt_is_eof(const struct tlog_pkt *pkt);
 
 /**
  * Check if contents of one packet is equal to the contents of another one.

--- a/include/tlog/sink.h
+++ b/include/tlog/sink.h
@@ -106,6 +106,15 @@ extern tlog_grc tlog_sink_cut(struct tlog_sink *sink);
 extern tlog_grc tlog_sink_flush(struct tlog_sink *sink);
 
 /**
+ * Close I/O fd of a tty sink.
+ *
+ * @param sink   The sink to close an associated I/O file descriptor.
+ * @param output True if sink output will be closed, false if sink
+ *               input will be closed.
+ */
+extern void tlog_sink_io_close(struct tlog_sink *sink, bool output);
+
+/**
  * Destroy (cleanup and free) a log sink.
  *
  * @param sink  Pointer to the sink to destroy, can be NULL.

--- a/include/tlog/sink_type.h
+++ b/include/tlog/sink_type.h
@@ -95,6 +95,15 @@ typedef tlog_grc (*tlog_sink_type_cut_fn)(struct tlog_sink *sink);
 typedef tlog_grc (*tlog_sink_type_flush_fn)(struct tlog_sink *sink);
 
 /**
+ * IO Close function prototype.
+ *
+ * @param sink    The sink to close an associated I/O file descriptor.
+ * @param output  Indicates which sink file descriptor to close.
+ */
+typedef void (*tlog_sink_type_io_close_fn)(struct tlog_sink *sink,
+                                           bool output);
+
+/**
  * Cleanup function prototype.
  *
  * @param sink  The sink to cleanup.
@@ -109,6 +118,7 @@ struct tlog_sink_type {
     tlog_sink_type_write_fn     write;      /**< Writing function */
     tlog_sink_type_cut_fn       cut;        /**< I/O-cutting function */
     tlog_sink_type_flush_fn     flush;      /**< Flushing function */
+    tlog_sink_type_io_close_fn  io_close;   /**< I/O-close function */
     tlog_sink_type_cleanup_fn   cleanup;    /**< Cleanup function */
 };
 

--- a/lib/tlitest/test_tlog_rec_session.py
+++ b/lib/tlitest/test_tlog_rec_session.py
@@ -4,7 +4,7 @@ import stat
 import time
 import inspect
 from tempfile import mkdtemp
-
+from subprocess import Popen, PIPE, STDOUT
 import pytest
 
 from misc import check_recording, mklogfile, mkcfgfile, \
@@ -202,6 +202,17 @@ class TestTlogRecSession:
         shell.sendline('echo $SHELL')
         check_recording(shell, '/usr/bin/tcsh', logfile)
         shell.sendline('exit')
+
+    def test_session_record_pipe_io_stdin(self):
+        """
+        Pipe I/O through stdin
+        """
+        text_in_stdio = 'print("hello world")\n'
+        text_out = "hello world"
+        p = Popen(['sshpass', '-p', 'Secret123', 'ssh', 'tlitestlocaluser2@localhost', 'python3.7'],
+        stdout=PIPE, stdin=PIPE, stderr=PIPE, encoding='utf8')
+        stdout_data = p.communicate(input=text_in_stdio)[0]
+        assert text_out in stdout_data
 
     @classmethod
     def teardown_class(cls):

--- a/lib/tlog/pkt.c
+++ b/lib/tlog/pkt.c
@@ -66,6 +66,21 @@ tlog_pkt_init_window(struct tlog_pkt *pkt,
 }
 
 void
+tlog_pkt_init_eof(struct tlog_pkt *pkt,
+                  const struct timespec *timestamp,
+                  bool output)
+{
+    assert(pkt != NULL);
+    memset(pkt, 0, sizeof(*pkt));
+    pkt->timestamp = *timestamp;
+    pkt->type = TLOG_PKT_TYPE_IO;
+    pkt->data.io.output = output;
+    pkt->data.io.len = 0;
+    assert(tlog_pkt_is_valid(pkt));
+    assert(tlog_pkt_is_eof(pkt));
+}
+
+void
 tlog_pkt_init_io(struct tlog_pkt *pkt,
                  const struct timespec *timestamp,
                  bool output,
@@ -112,6 +127,13 @@ tlog_pkt_is_void(const struct tlog_pkt *pkt)
 {
     assert(tlog_pkt_is_valid(pkt));
     return pkt->type == TLOG_PKT_TYPE_VOID;
+}
+
+bool
+tlog_pkt_is_eof(const struct tlog_pkt *pkt)
+{
+    assert(tlog_pkt_is_valid(pkt));
+    return pkt->type == TLOG_PKT_TYPE_IO && pkt->data.io.len == 0;
 }
 
 bool

--- a/lib/tlog/sink.c
+++ b/lib/tlog/sink.c
@@ -136,6 +136,17 @@ tlog_sink_flush(struct tlog_sink *sink)
 }
 
 void
+tlog_sink_io_close(struct tlog_sink *sink,
+                bool output)
+{
+    assert(tlog_sink_is_valid(sink));
+
+    if (sink->type->io_close != NULL) {
+        sink->type->io_close(sink, output);
+    }
+}
+
+void
 tlog_sink_destroy(struct tlog_sink *sink)
 {
     assert(sink == NULL || tlog_sink_is_valid(sink));

--- a/lib/tlog/source.c
+++ b/lib/tlog/source.c
@@ -117,7 +117,7 @@ tlog_source_read(struct tlog_source *source, struct tlog_pkt *pkt)
     assert(grc == TLOG_RC_OK || tlog_pkt_is_void(pkt));
     assert(tlog_source_is_valid(source));
 #ifndef NDEBUG
-    if (!tlog_pkt_is_void(pkt)) {
+    if (!tlog_pkt_is_void(pkt) && !tlog_pkt_is_eof(pkt)) {
         tlog_timespec_sub(&pkt->timestamp, &source->last_timestamp, &diff);
         assert(tlog_timespec_cmp(&diff, &tlog_timespec_zero) >= 0);
         assert(tlog_timespec_cmp(&diff, &tlog_delay_max_timespec) <= 0);

--- a/lib/tlog/tty_sink.c
+++ b/lib/tlog/tty_sink.c
@@ -52,6 +52,20 @@ tlog_tty_sink_is_valid(const struct tlog_sink *sink)
 }
 
 static void
+tlog_tty_sink_io_close(struct tlog_sink *sink, bool output)
+{
+    struct tlog_tty_sink *tty_sink =
+                                (struct tlog_tty_sink *)sink;
+
+    int *fd = output ? &tty_sink->out_fd : &tty_sink->in_fd;
+
+    if (*fd >= 0) {
+        close(*fd);
+        *fd = -1;
+    }
+}
+
+static void
 tlog_tty_sink_cleanup(struct tlog_sink *sink)
 {
     struct tlog_tty_sink *tty_sink =
@@ -124,4 +138,5 @@ const struct tlog_sink_type tlog_tty_sink_type = {
     .cleanup    = tlog_tty_sink_cleanup,
     .is_valid   = tlog_tty_sink_is_valid,
     .write      = tlog_tty_sink_write,
+    .io_close   = tlog_tty_sink_io_close,
 };

--- a/src/tlitest/tlitest-setup
+++ b/src/tlitest/tlitest-setup
@@ -7,6 +7,7 @@ python3-pytest
 python3-pexpect
 python3-systemd
 tcsh
+sshpass
 tlog
 "
 PKGSFILE="/tmp/tlitest-setup_packages_found"


### PR DESCRIPTION
Modify the main recording loop to transfer I/O until an EOF
is signalled only from the forked recorded process.

Also add functionality to close input or output file descriptors
to the sink interface. This is necessary to close one end of a pipe
when I/O is pushed to an interactive process like python via stdin.

Resolves https://github.com/Scribery/tlog/issues/227