### PR TITLE
issue 283: tlog-play improve auth options. 

### DIFF
--- a/include/tlog/es_json_reader.h
+++ b/include/tlog/es_json_reader.h
@@ -78,13 +78,14 @@ static inline tlog_grc
 tlog_es_json_reader_create(struct tlog_json_reader **preader,
                            const char *base_url,
                            const char *query,
-                           size_t size)
+                           size_t size,
+                           bool verbose)
 {
     assert(preader != NULL);
     assert(tlog_es_json_reader_base_url_is_valid(base_url));
     assert(query != NULL);
     return tlog_json_reader_create(preader, &tlog_es_json_reader_type,
-                                   base_url, query, size);
+                                   base_url, query, size, verbose);
 }
 
 #endif /* _TLOG_ES_JSON_READER_H */

--- a/lib/tlog/play.c
+++ b/lib/tlog/play.c
@@ -82,6 +82,7 @@ tlog_play_create_es_json_reader(struct tlog_errs **perrs,
     tlog_grc grc;
     const char *baseurl;
     const char *query;
+    bool verbose;
     struct tlog_json_reader *reader = NULL;
     struct json_object *obj;
 
@@ -94,6 +95,10 @@ tlog_play_create_es_json_reader(struct tlog_errs **perrs,
         TLOG_ERRS_RAISES("Elasticsearch base URL is not specified");
     }
     baseurl = json_object_get_string(obj);
+
+    /* Check for the verbose flag */
+    verbose = json_object_object_get_ex(conf, "verbose", &obj) &&
+        json_object_get_boolean(obj);
 
     /* Check base URL validity */
     if (!tlog_es_json_reader_base_url_is_valid(baseurl)) {
@@ -109,7 +114,7 @@ tlog_play_create_es_json_reader(struct tlog_errs **perrs,
     query = json_object_get_string(obj);
 
     /* Create the reader */
-    grc = tlog_es_json_reader_create(&reader, baseurl, query, 10);
+    grc = tlog_es_json_reader_create(&reader, baseurl, query, 10, verbose);
     if (grc != TLOG_RC_OK) {
         TLOG_ERRS_RAISECS(grc, "Failed creating the Elasticsearch reader");
     }

--- a/m4/tlog/play_conf_schema.m4
+++ b/m4/tlog/play_conf_schema.m4
@@ -92,6 +92,12 @@ M4_PARAM(`/es', `query', `file-',
          `STRING is the ', `The ',
          `M4_LINES(`query string to send to Elasticsearch')')m4_dnl
 m4_dnl
+M4_PARAM(`/es', `verbose', `file-',
+         `M4_TYPE_BOOL(false)', true,
+         `', `', `Enable verbose output on Elasticsearch HTTP client',
+         `If specified, ', `If true, ',
+         `M4_LINES(`enable verbose output on Elasticsearch HTTP client.')')m4_dnl
+m4_dnl
 m4_dnl
 m4_dnl
 m4_ifelse(M4_JOURNAL_ENABLED(), `1', `m4_dnl


### PR DESCRIPTION
As well as being able to specify authentication in the URL, provide some other
options for configuring the curl client that connects to the ElasticSearch API.

* user:pass in the TLOG_CURL_USERPWD environment variable
* In a ~/.netrc file
* Enable GSSNEGOTIATE for Kerberos support.

For kerberos the username must be non-empty, either in the URL or $TLOG_CURL_USERPWD.