### PR TITLE
[RFC] fix issue #280

### DIFF
--- a/include/tlog/tap.h
+++ b/include/tlog/tap.h
@@ -32,18 +32,25 @@
 #include <termios.h>
 #include <unistd.h>
 #include <time.h>
+#include <utmpx.h>
+
+#define TLOG_TAP_UTMP_LINESIZE (sizeof(((struct utmpx *)0)->ut_line))
+#define TLOG_TAP_DEVPATH "/dev/"
+#define TLOG_TAP_PTSPATH TLOG_TAP_DEVPATH "pts/"
+#define TLOG_TAP_DEVSIZE (sizeof(TLOG_TAP_DEVPATH) - 1)
 
 /** I/O tap state */
 struct tlog_tap {
-    pid_t               pid;            /**< Shell PID */
-    struct tlog_source *source;         /**< TTY data source */
-    struct tlog_sink   *sink;           /**< TTY data sink */
-    int                 in_fd;          /**< Shell input FD */
-    int                 out_fd;         /**< Shell output FD */
-    int                 tty_fd;         /**< Controlling terminal FD, or -1 */
-    struct termios      termios_orig;   /**< Original terminal attributes */
-    bool                termios_set;    /**< True if terminal attributes were
-                                             changed from the original */
+    pid_t               pid;                    /**< Shell PID */
+    struct tlog_source *source;                 /**< TTY data source */
+    struct tlog_sink   *sink;                   /**< TTY data sink */
+    struct utmpx       *ut;                     /**< utmp entry */
+    int                 in_fd;                  /**< Shell input FD */
+    int                 out_fd;                 /**< Shell output FD */
+    int                 tty_fd;                 /**< Controlling terminal FD, or -1 */
+    struct termios      termios_orig;           /**< Original terminal attributes */
+    bool                termios_set;            /**< True if terminal attributes were
+                                                     changed from the original */
 };
 
 /** A void I/O tap state initializer */
@@ -51,6 +58,7 @@ struct tlog_tap {
     (struct tlog_tap) {      \
         .source = NULL, \
         .sink   = NULL, \
+        .ut     = NULL, \
         .in_fd  = -1,   \
         .out_fd = -1,   \
         .tty_fd = -1,   \
@@ -59,17 +67,18 @@ struct tlog_tap {
 /**
  * Setup I/O tap.
  *
- * @param perrs     Location for the error stack. Can be NULL.
- * @param ptap      Location for the tap state.
- * @param euid      The effective UID the program was started with.
- * @param egid      The effective GID the program was started with.
- * @param opts      Execution options: a bitmask of TLOG_EXEC_OPT_* bits.
- * @param path      Path to the recorded program to execute.
- * @param argv      ARGV array for the recorded program.
- * @param in_fd     Stdin to connect to, or -1 if none.
- * @param out_fd    Stdout to connect to, or -1 if none.
- * @param err_fd    Stderr to connect to, or -1 if none.
- * @param clock_id  Clock to use for timestamps.
+ * @param perrs        Location for the error stack. Can be NULL.
+ * @param ptap         Location for the tap state.
+ * @param euid         The effective UID the program was started with.
+ * @param egid         The effective GID the program was started with.
+ * @param opts         Execution options: a bitmask of TLOG_EXEC_OPT_* bits.
+ * @param path         Path to the recorded program to execute.
+ * @param argv         ARGV array for the recorded program.
+ * @param in_fd        Stdin to connect to, or -1 if none.
+ * @param out_fd       Stdout to connect to, or -1 if none.
+ * @param err_fd       Stderr to connect to, or -1 if none.
+ * @param clock_id     Clock to use for timestamps.
+ * @param update_utmp  Attempt updating utmp if true.
  *
  * @return Global return code.
  */
@@ -79,7 +88,8 @@ extern tlog_grc tlog_tap_setup(struct tlog_errs **perrs,
                                unsigned int opts,
                                const char *path, char **argv,
                                int in_fd, int out_fd, int err_fd,
-                               clockid_t clock_id);
+                               clockid_t clock_id,
+                               bool update_utmp);
 
 /**
  * Teardown an I/O tap state.

--- a/lib/tlitest/config.py
+++ b/lib/tlitest/config.py
@@ -18,6 +18,7 @@ DEFAULT_TLOG_REC_SYSLOG_PRIORITY = "info"
 
 DEFAULT_TLOG_REC_SESSION_SHELL = "/bin/bash"
 DEFAULT_TLOG_REC_SESSION_NOTICE = "ATTENTION: Your session is being recorded!"
+DEFAULT_TLOG_REC_SESSION_UPDATE_UTMP = False
 DEFAULT_TLOG_REC_SESSION_WRITER = "journal"
 
 DEFAULT_TLOG_PLAY_READER = "file"
@@ -183,9 +184,10 @@ class TlogRecConfig:
 
 
 class TlogRecSessionConfig(TlogRecConfig):
-    """TlogPlaySession configuration class, child of TlogRecConfig"""
+    """TlogRecSession configuration class, child of TlogRecConfig"""
     def __init__(self, shell=DEFAULT_TLOG_REC_SESSION_SHELL,
                  notice=DEFAULT_TLOG_REC_SESSION_NOTICE,
+                 update_utmp=DEFAULT_TLOG_REC_SESSION_UPDATE_UTMP,
                  latency=DEFAULT_TLOG_REC_LATENCY,
                  payload=DEFAULT_TLOG_REC_PAYLOAD,
                  log_input=DEFAULT_TLOG_REC_LOG_INPUT,
@@ -201,6 +203,7 @@ class TlogRecSessionConfig(TlogRecConfig):
                  syslog_priority=DEFAULT_TLOG_REC_SYSLOG_PRIORITY):
         self.shell = shell
         self.notice = notice
+        self.update_utmp = update_utmp
         super().__init__(latency, payload, log_input, log_output, log_window,
                          limit_rate, limit_burst, limit_action,
                          writer, file_writer_path, journal_priority,
@@ -212,6 +215,7 @@ class TlogRecSessionConfig(TlogRecConfig):
         tlog_rec_session_config = {
             "shell": self.shell,
             "notice": self.notice,
+            "update-utmp": self.update_utmp,
         }
 
         return tlog_rec_session_config

--- a/lib/tlitest/test_tlog_rec_session.py
+++ b/lib/tlitest/test_tlog_rec_session.py
@@ -214,6 +214,21 @@ class TestTlogRecSession:
         stdout_data = p.communicate(input=text_in_stdio)[0]
         assert text_out in stdout_data
 
+    def test_session_record_update_utmp(self):
+        """
+        Update_utmp functionality test
+        """
+        myname = inspect.stack()[0][3]
+        logfile = mklogfile(self.tempdir)
+        sessionclass = TlogRecSessionConfig(update_utmp=True,
+                                            writer="file",
+                                            file_writer_path=logfile)
+        sessionclass.generate_config(SYSTEM_TLOG_REC_SESSION_CONF)
+        shell = ssh_pexpect(self.user, 'Secret123', 'localhost')
+        shell.sendline('echo {}'.format(myname))
+        check_recording(shell, myname, logfile)
+        shell.close()
+
     @classmethod
     def teardown_class(cls):
         """ Copy original conf file back into place """

--- a/lib/tlog/rec.c
+++ b/lib/tlog/rec.c
@@ -1126,6 +1126,7 @@ tlog_rec(struct tlog_errs **perrs, uid_t euid, gid_t egid,
     unsigned int item_mask;
     int signal = 0;
     struct tlog_sink *log_sink = NULL;
+    bool update_utmp;
     struct tlog_tap tap = TLOG_TAP_VOID;
 
     assert(cmd_help != NULL);
@@ -1243,10 +1244,14 @@ tlog_rec(struct tlog_errs **perrs, uid_t euid, gid_t egid,
         fprintf(stderr, "%s", json_object_get_string(obj));
     }
 
+    /* Check if we will update utmp */
+    update_utmp = json_object_object_get_ex(conf, "update-utmp", &obj) &&
+        json_object_get_boolean(obj);
+
     /* Setup the tap */
     grc = tlog_tap_setup(perrs, &tap, euid, egid,
                          opts & TLOG_EXEC_OPT_MASK, path, argv,
-                         in_fd, out_fd, err_fd, clock_id);
+                         in_fd, out_fd, err_fd, clock_id, update_utmp);
     if (grc != TLOG_RC_OK) {
         TLOG_ERRS_RAISES("Failed setting up the I/O tap");
     }

--- a/lib/tlog/tap.c
+++ b/lib/tlog/tap.c
@@ -32,6 +32,133 @@
 #include <time.h>
 #include <semaphore.h>
 #include <assert.h>
+#include <limits.h>
+#include <ctype.h>
+#include <string.h>
+#include <sys/types.h>
+#include <pwd.h>
+
+/**
+ * Add an utmp entry for this session.
+ *
+ * @param tap   tlog_tap structure address.
+ * @param path  The filename of the slave pty.
+ * @param perrs Location for the error stack
+ * @param euid  The EUID to use while updating utmp
+ * @param egid  The EGID to use while updating utmp
+ *
+ * @return Global return code.
+ */
+static tlog_grc
+tlog_tap_add_utmp_entry(struct tlog_tap *tap, char *path,
+                        struct tlog_errs **perrs,
+                        uid_t euid, gid_t egid)
+{
+    tlog_grc grc;
+    int ofs;
+    struct timeval tv;
+    char *ses_line;
+    struct utmpx ut;
+    struct utmpx *ut_ptr;
+
+    if ((ses_line = ttyname(tap->tty_fd)) == NULL) {
+        grc = TLOG_GRC_ERRNO;
+        TLOG_ERRS_RAISECS(grc, "Failed retrieving terminal name");
+    }
+
+    if (gettimeofday(&tv, NULL) < 0) {
+        grc = TLOG_RC_FAILURE;
+        TLOG_ERRS_RAISES("Failure obtaining the current time");
+    }
+
+    if ((tap->ut = calloc(sizeof(*tap->ut), 1)) == NULL) {
+        grc = TLOG_GRC_FROM(errno, ENOMEM);
+        goto cleanup;
+    }
+
+    /* Set basic utmp entry data */
+    memset(&ut, 0, sizeof(struct utmpx));
+    strncpy(ut.ut_user, getpwuid(getuid())->pw_name, sizeof(ut.ut_user));
+    ut.ut_type = USER_PROCESS;
+    ut.ut_pid = tap->pid;
+
+    /* Strip the leading "/dev/" to get the line name */
+    ofs = strncmp(path, TLOG_TAP_DEVPATH, TLOG_TAP_DEVSIZE) == 0 ? TLOG_TAP_DEVSIZE : 0;
+    strcpy(ut.ut_line, path + ofs);
+
+    /* Copy the trailing pty number to ut_id */
+    strcpy(ut.ut_id, path + strlen(TLOG_TAP_PTSPATH));
+
+    /* Set the session start time */
+    ut.ut_tv.tv_sec = tv.tv_sec;
+    ut.ut_tv.tv_usec = tv.tv_usec;
+
+    /* Find the current session utmp entry, if any, and copy the remaining
+     * data to the new entry */
+    ofs = strncmp(ses_line, TLOG_TAP_DEVPATH, TLOG_TAP_DEVSIZE) == 0 ? TLOG_TAP_DEVSIZE : 0;
+    ses_line += ofs;
+    while ((ut_ptr = getutxent()) != NULL &&
+            (ut_ptr->ut_type != USER_PROCESS || strncmp(ut_ptr->ut_line, ses_line, TLOG_TAP_UTMP_LINESIZE)))
+        ;
+    if (ut_ptr) {
+        memcpy(ut.ut_host, ut_ptr->ut_host, sizeof(ut_ptr->ut_host));
+        ut.ut_session = ut_ptr->ut_session;
+        memcpy(ut.ut_addr_v6, ut_ptr->ut_addr_v6, sizeof(ut_ptr->ut_addr_v6));
+    }
+
+    /* Add the new session entry */
+    setutxent();
+    TLOG_EVAL_WITH_EUID_EGID(euid, egid, ut_ptr = pututxline(&ut));
+    endutxent();
+
+    if (ut_ptr == NULL) {
+        free(tap->ut);
+        tap->ut = NULL;
+        grc = TLOG_GRC_ERRNO;
+        TLOG_ERRS_RAISECS(grc, "Failed writing utmp entry to file");
+    }
+
+    memcpy(tap->ut, &ut, sizeof(ut));
+    grc = TLOG_RC_OK;
+
+cleanup:
+
+    return grc;
+}
+
+/**
+ * Remove the utmp entry for this session.
+ *
+ * @param tap       tlog_tap structure address.
+ * @param wstatus   process status information.
+ *
+ * @return zero, or -1 in case of error with errno set.
+ */
+static int
+tlog_tap_remove_utmp_entry(struct tlog_tap *tap, int wstatus)
+{
+    int res = 0;
+    struct utmpx ut;
+
+    if (tap->ut) {
+        memcpy(&ut, tap->ut, sizeof(ut));
+        free(tap->ut);
+        tap->ut = NULL;
+        ut.ut_type = DEAD_PROCESS;
+        memset(&ut.ut_user, 0, sizeof(ut.ut_user));
+        memset(ut.ut_host, 0, sizeof(ut.ut_host));
+        ut.ut_exit.e_termination = WIFSIGNALED(wstatus) ? WTERMSIG(wstatus) : 0;
+        ut.ut_exit.e_exit = WEXITSTATUS(wstatus);
+        ut.ut_tv.tv_sec = 0;
+        ut.ut_tv.tv_usec = 0;
+        setutxent();
+        if (pututxline(&ut) == NULL) {
+            res = -1;
+        }
+        endutxent();
+    }
+    return res;
+}
 
 /**
  * Fork a child connected via a pair of pipes.
@@ -146,7 +273,8 @@ tlog_tap_setup(struct tlog_errs **perrs,
                uid_t euid, gid_t egid,
                unsigned int opts, const char *path, char **argv,
                int in_fd, int out_fd, int err_fd,
-               clockid_t clock_id)
+               clockid_t clock_id,
+               bool update_utmp)
 {
     tlog_grc grc;
     struct tlog_tap tap = TLOG_TAP_VOID;
@@ -198,6 +326,7 @@ tlog_tap_setup(struct tlog_errs **perrs,
     if (tap.tty_fd >= 0) {
         struct winsize winsize;
         int master_fd;
+        char slave_path[PATH_MAX];
 
         /* Get terminal window size */
         if (ioctl(tap.tty_fd, TIOCGWINSZ, &winsize) < 0) {
@@ -206,7 +335,7 @@ tlog_tap_setup(struct tlog_errs **perrs,
         }
 
         /* Fork a child connected via a PTY */
-        tap.pid = forkpty(&master_fd, NULL, &tap.termios_orig, &winsize);
+        tap.pid = forkpty(&master_fd, slave_path, &tap.termios_orig, &winsize);
         if (tap.pid < 0) {
             grc = TLOG_GRC_ERRNO;
             TLOG_ERRS_RAISECS(grc,
@@ -220,6 +349,15 @@ tlog_tap_setup(struct tlog_errs **perrs,
             if (tap.out_fd < 0) {
                 grc = TLOG_GRC_ERRNO;
                 TLOG_ERRS_RAISECS(grc, "Failed duplicating PTY master FD");
+            }
+
+            /* Add the utmp entry */
+            if (update_utmp) {
+                grc = tlog_tap_add_utmp_entry(&tap, slave_path, perrs,
+                                              euid, egid);
+                if (grc != TLOG_RC_OK) {
+                    TLOG_ERRS_RAISES("Failed adding utmp entry");
+                }
             }
         }
     } else {
@@ -321,7 +459,8 @@ tlog_tap_teardown(struct tlog_errs **perrs,
                   struct tlog_tap *tap,
                   int *pstatus)
 {
-    tlog_grc grc;
+    tlog_grc grc = TLOG_RC_OK;
+    int wstatus = 0;
 
     assert(tap != NULL);
 
@@ -349,7 +488,7 @@ tlog_tap_teardown(struct tlog_errs **perrs,
             grc = TLOG_GRC_ERRNO;
             tlog_errs_pushc(perrs, grc);
             tlog_errs_pushs(perrs, "Failed restoring TTY attributes");
-            return grc;
+            goto cleanup;
         }
         tap->termios_set = false;
 
@@ -359,24 +498,31 @@ tlog_tap_teardown(struct tlog_errs **perrs,
             grc = TLOG_GRC_ERRNO;
             tlog_errs_pushc(perrs, grc);
             tlog_errs_pushs(perrs, "Failed writing newline to TTY");
-            return grc;
+            goto cleanup;
         }
     }
 
     /* Wait for the child, if any */
     if (tap->pid > 0) {
-        if (waitpid(tap->pid, pstatus, 0) < 0) {
+        if (waitpid(tap->pid, &wstatus, 0) < 0) {
             grc = TLOG_GRC_ERRNO;
             tlog_errs_pushc(perrs, grc);
             tlog_errs_pushs(perrs, "Failed waiting for the child");
-            return grc;
+            goto cleanup;
         }
         tap->pid = 0;
-    } else {
-        if (pstatus != NULL) {
-            *pstatus = 0;
+        if (tlog_tap_remove_utmp_entry(tap, wstatus) < 0) {
+            grc = TLOG_GRC_ERRNO;
+            tlog_errs_pushc(perrs, grc);
+            tlog_errs_pushs(perrs, "Failed removing utmp entry");
+            goto cleanup;
         }
     }
 
-    return TLOG_RC_OK;
+cleanup:
+
+    if (pstatus != NULL) {
+        *pstatus = wstatus;
+    }
+    return grc;
 }

--- a/m4/tlog/conf_cmd.m4
+++ b/m4/tlog/conf_cmd.m4
@@ -42,7 +42,7 @@ m4_define(
                     `
                         m4_print(
                             `        OPT',
-                            m4_translit(m4_translit(`$1/$2', `/', `_'), `a-z', `A-Z'),
+                            m4_translit(`$1/$2', `-/a-z', `__A-Z'),
                             ` = ',
                             `m4_singlequote(`$6')')
                         m4_printl(`,')
@@ -72,7 +72,7 @@ m4_define(
                     `
                         m4_print(
                             `        OPT',
-                            m4_translit(m4_translit(`$1/$2', `/', `_'), `a-z', `A-Z'))
+                            m4_translit(`$1/$2', `-/a-z', `__A-Z'))
                         m4_ifelse(
                             M4_FIRST(),
                             `true',
@@ -175,7 +175,7 @@ m4_define(
                    `            .name = "m4_substr(m4_translit(`$1/$2', `/', `-'), 1)",')
                 m4_print(
                    `            .val = OPT',
-                   m4_translit(m4_translit(`$1/$2', `/', `_'), `a-z', `A-Z'))
+                   m4_translit(`$1/$2', `-/a-z', `__A-Z'))
                 m4_printl(
                    `,',
                    `            .has_arg = $4,',
@@ -473,7 +473,7 @@ m4_define(
             `
                 m4_print(
                    `        case OPT',
-                   m4_translit(m4_translit(`$1/$2', `/', `_'), `a-z', `A-Z'))
+                   m4_translit(`$1/$2', `-/a-z', `__A-Z'))
                 m4_printl(
                     `:')
                 m4_print(

--- a/m4/tlog/rec_session_conf_schema.m4
+++ b/m4/tlog/rec_session_conf_schema.m4
@@ -61,6 +61,16 @@ M4_PARAM(`', `notice', `file-env',
                    `recording and the user shell. Can be used to warn',
                    `the user that the session is recorded.')')m4_dnl
 m4_dnl
+M4_PARAM(`', `update-utmp', `name-file-env',
+          `M4_TYPE_BOOL(false)', true,
+          `u', `', `Enable/disable updating the system utmp file',
+          `If specified, ', `If true, ',
+          `M4_LINES(`tlog-rec-session attempts to set a USER_PROCESS utmp entry.',
+                    `The recorded user must have permission to update the utmp',
+                    `file, likely as a member of the utmp group. Alternatively',
+                    `tlog-rec-session may be installed belonging to the utmp',
+                    `group and with the setgit bit set.')')m4_dnl
+m4_dnl
 m4_dnl
 m4_dnl Include common schema, but limit its scope to environment
 m4_dnl

--- a/src/tlitest/tlitest-setup
+++ b/src/tlitest/tlitest-setup
@@ -58,4 +58,5 @@ echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > \
 
 usermod tlitestlocaladmin1 -aG wheel,systemd-journal
 usermod tlitestlocaluser1 -aG systemd-journal
+usermod tlitestlocaluser2 -aG utmp
 usermod tlitestlocaluser2 -s /usr/bin/tlog-rec-session


### PR DESCRIPTION
Add code to tlog_tap_setup and tlog_tap_teardown to add/invalidade utmp
entries for the shell subprocess.

At the moment this requires write permission to /run/utmp, so the user
must belong to the "utmp" group.

Fixes:
  - https://github.com/Scribery/tlog/issues/280
  - https://bugzilla.redhat.com/show_bug.cgi?id=1811794

Signed-off-by: Carlos Santos <casantos@redhat.com>