### PR TITLE
Use -Og compiler Optimization due to default hardening

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ AC_ARG_ENABLE(
 # Output features to preprocessor and compiler
 if test "$tlog_debug_enabled" = "yes"; then
     CPPFLAGS="$CPPFLAGS -UNDEBUG"
-    CFLAGS="$CFLAGS -Wall -Wextra -Werror -g -O0"
+    CFLAGS="$CFLAGS -Wall -Wextra -Werror -g -Og"
 fi
 
 # Check for libraries


### PR DESCRIPTION
I'm not sure if this is necessary, I only ran into this problem when attempting to build a 
rpm with `--enable-debug` enabled. The gcc man page documentation indicates that `-Og` is a suitable debugging optimization.

Using gcc's 0 Optimization (-O0) flag causes warnings when tlog is
build with -D_FORTIFY_SOURCE=2, this causes ./configure --enable-debug
to fail when building a rpm using a spec file:

    warning _FORTIFY_SOURCE requires compiling with optimization