### PR TITLE
Install tlog-rec-session with utmp group ownership

### DIFF
--- a/.github/workflows/tlog-tests.yml
+++ b/.github/workflows/tlog-tests.yml
@@ -33,6 +33,6 @@ jobs:
     - name: permission setup
       run: sudo chmod g+s /usr/bin/tlog-rec-session
     - name: permission setup
-      run: sudo chown tlog:tlog /var/run/tlog
+      run: sudo chown tlog:utmp /var/run/tlog
     - name: intg tests
       run: sudo src/tlitest/tlitest-run

--- a/tlog.spec
+++ b/tlog.spec
@@ -110,7 +110,7 @@ rm -r %{buildroot}/usr/include/%{name}
 %license COPYING
 %doc %{_defaultdocdir}/%{name}
 %{_bindir}/%{name}-rec
-%attr(6755,%{name},%{name}) %{_bindir}/%{name}-rec-session
+%attr(6755,%{name},utmp) %{_bindir}/%{name}-rec-session
 %{_bindir}/%{name}-play
 %{_libdir}/lib%{name}.so*
 %{_datadir}/%{name}


### PR DESCRIPTION
Enables support for SGID update-utmp functionality implemented in https://github.com/Scribery/tlog/commit/60cc06f1b073eaa309422e135b4c5ac99f33c937