### PR TITLE
Add libutempter support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
             - libjson-c-dev
             - libcurl4-gnutls-dev
             - libsystemd-dev
+            - libutempter-dev
             - clang
             - lcov
             - rpm

--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ and `tlog-rec-session`.
 Building
 --------
 
-Build dependencies are systemd, cURL, and json-c, which development packages
-are `systemd-devel`, `json-c-devel`, and `libcurl-devel` on RPM-based distros,
-and `pkg-config`, `libjson-c-dev`, `libsystemd-journal-dev`/`libsystemd-dev`
-and `libcurl-*-dev` on Debian-based distros.
+Build dependencies are systemd, cURL, json-c, and libutempter, which development
+packages are `systemd-devel`, `json-c-devel`, `libcurl-devel`, and
+`libutempter-devel` on RPM-based distros, and `pkg-config`, `libjson-c-dev`,
+`libsystemd-journal-dev`/`libsystemd-dev`, `libcurl-*-dev`, and `libutempter-dev`
+on Debian-based distros.
 
 To build from Git you'll need `autoconf`, `automake` and `libtool` packages.
 For creating RPM package `rpm-build` is also required.
@@ -43,6 +44,9 @@ For creating RPM package `rpm-build` is also required.
 If Systemd Journal support is not required, it can be disabled with
 configure's `--disable-journal` option, removing the systemd dependency as
 well.
+
+Updating the system utmp and wtmp files can be enabled with the
+`--enable-utempter` configure option, utilizing the libutempter library.
 
 If you'd like to build `tlog` from the Git source tree, you need to first
 generate the build system files:

--- a/configure.ac
+++ b/configure.ac
@@ -56,10 +56,30 @@ AC_ARG_ENABLE(
     AS_HELP_STRING([--disable-journal], [disable support for Systemd Journal]),
     [tlog_journal_enabled="$enableval"], [tlog_journal_enabled="yes"])
 
+AC_ARG_ENABLE(
+    utempter,
+    AS_HELP_STRING([--enable-utempter], [enable support for utempter]),
+    [tlog_utempter_enabled="$enableval"], [tlog_utempter_enabled="no"])
+
 # Output features to preprocessor and compiler
 if test "$tlog_debug_enabled" = "yes"; then
     CPPFLAGS="$CPPFLAGS -UNDEBUG"
     CFLAGS="$CFLAGS -Wall -Wextra -Werror -g -O0"
+fi
+
+if test "$tlog_utempter_enabled" = "yes"; then
+    AC_SEARCH_LIBS(
+       utempter_add_record,
+       utempter,
+       tlog_utempter_enabled=yes,
+       tlog_utempter_enabled=no
+    )
+    if test "$tlog_utempter_enabled" = "yes"; then
+        AC_DEFINE([HAVE_UTEMPTER], [1],
+                  [Define to 1 if utempter support is enabled])
+    else
+        AC_MSG_ERROR([libutempter not found])
+    fi
 fi
 
 # Check for libraries

--- a/include/tlog/tap.h
+++ b/include/tlog/tap.h
@@ -32,6 +32,9 @@
 #include <termios.h>
 #include <unistd.h>
 #include <time.h>
+#ifdef HAVE_UTEMPTER
+#include <utempter.h>
+#endif
 
 /** I/O tap state */
 struct tlog_tap {

--- a/include/tlog/tap.h
+++ b/include/tlog/tap.h
@@ -32,25 +32,18 @@
 #include <termios.h>
 #include <unistd.h>
 #include <time.h>
-#include <utmpx.h>
-
-#define TLOG_TAP_UTMP_LINESIZE (sizeof(((struct utmpx *)0)->ut_line))
-#define TLOG_TAP_DEVPATH "/dev/"
-#define TLOG_TAP_PTSPATH TLOG_TAP_DEVPATH "pts/"
-#define TLOG_TAP_DEVSIZE (sizeof(TLOG_TAP_DEVPATH) - 1)
 
 /** I/O tap state */
 struct tlog_tap {
-    pid_t               pid;                    /**< Shell PID */
-    struct tlog_source *source;                 /**< TTY data source */
-    struct tlog_sink   *sink;                   /**< TTY data sink */
-    struct utmpx       *ut;                     /**< utmp entry */
-    int                 in_fd;                  /**< Shell input FD */
-    int                 out_fd;                 /**< Shell output FD */
-    int                 tty_fd;                 /**< Controlling terminal FD, or -1 */
-    struct termios      termios_orig;           /**< Original terminal attributes */
-    bool                termios_set;            /**< True if terminal attributes were
-                                                     changed from the original */
+    pid_t               pid;            /**< Shell PID */
+    struct tlog_source *source;         /**< TTY data source */
+    struct tlog_sink   *sink;           /**< TTY data sink */
+    int                 in_fd;          /**< Shell input FD */
+    int                 out_fd;         /**< Shell output FD */
+    int                 tty_fd;         /**< Controlling terminal FD, or -1 */
+    struct termios      termios_orig;   /**< Original terminal attributes */
+    bool                termios_set;    /**< True if terminal attributes were
+                                             changed from the original */
 };
 
 /** A void I/O tap state initializer */
@@ -58,7 +51,6 @@ struct tlog_tap {
     (struct tlog_tap) {      \
         .source = NULL, \
         .sink   = NULL, \
-        .ut     = NULL, \
         .in_fd  = -1,   \
         .out_fd = -1,   \
         .tty_fd = -1,   \
@@ -67,18 +59,17 @@ struct tlog_tap {
 /**
  * Setup I/O tap.
  *
- * @param perrs        Location for the error stack. Can be NULL.
- * @param ptap         Location for the tap state.
- * @param euid         The effective UID the program was started with.
- * @param egid         The effective GID the program was started with.
- * @param opts         Execution options: a bitmask of TLOG_EXEC_OPT_* bits.
- * @param path         Path to the recorded program to execute.
- * @param argv         ARGV array for the recorded program.
- * @param in_fd        Stdin to connect to, or -1 if none.
- * @param out_fd       Stdout to connect to, or -1 if none.
- * @param err_fd       Stderr to connect to, or -1 if none.
- * @param clock_id     Clock to use for timestamps.
- * @param update_utmp  Attempt updating utmp if true.
+ * @param perrs     Location for the error stack. Can be NULL.
+ * @param ptap      Location for the tap state.
+ * @param euid      The effective UID the program was started with.
+ * @param egid      The effective GID the program was started with.
+ * @param opts      Execution options: a bitmask of TLOG_EXEC_OPT_* bits.
+ * @param path      Path to the recorded program to execute.
+ * @param argv      ARGV array for the recorded program.
+ * @param in_fd     Stdin to connect to, or -1 if none.
+ * @param out_fd    Stdout to connect to, or -1 if none.
+ * @param err_fd    Stderr to connect to, or -1 if none.
+ * @param clock_id  Clock to use for timestamps.
  *
  * @return Global return code.
  */
@@ -88,8 +79,7 @@ extern tlog_grc tlog_tap_setup(struct tlog_errs **perrs,
                                unsigned int opts,
                                const char *path, char **argv,
                                int in_fd, int out_fd, int err_fd,
-                               clockid_t clock_id,
-                               bool update_utmp);
+                               clockid_t clock_id);
 
 /**
  * Teardown an I/O tap state.

--- a/lib/tlitest/config.py
+++ b/lib/tlitest/config.py
@@ -18,7 +18,6 @@ DEFAULT_TLOG_REC_SYSLOG_PRIORITY = "info"
 
 DEFAULT_TLOG_REC_SESSION_SHELL = "/bin/bash"
 DEFAULT_TLOG_REC_SESSION_NOTICE = "ATTENTION: Your session is being recorded!"
-DEFAULT_TLOG_REC_SESSION_UPDATE_UTMP = False
 DEFAULT_TLOG_REC_SESSION_WRITER = "journal"
 
 DEFAULT_TLOG_PLAY_READER = "file"
@@ -184,10 +183,9 @@ class TlogRecConfig:
 
 
 class TlogRecSessionConfig(TlogRecConfig):
-    """TlogRecSession configuration class, child of TlogRecConfig"""
+    """TlogPlaySession configuration class, child of TlogRecConfig"""
     def __init__(self, shell=DEFAULT_TLOG_REC_SESSION_SHELL,
                  notice=DEFAULT_TLOG_REC_SESSION_NOTICE,
-                 update_utmp=DEFAULT_TLOG_REC_SESSION_UPDATE_UTMP,
                  latency=DEFAULT_TLOG_REC_LATENCY,
                  payload=DEFAULT_TLOG_REC_PAYLOAD,
                  log_input=DEFAULT_TLOG_REC_LOG_INPUT,
@@ -203,7 +201,6 @@ class TlogRecSessionConfig(TlogRecConfig):
                  syslog_priority=DEFAULT_TLOG_REC_SYSLOG_PRIORITY):
         self.shell = shell
         self.notice = notice
-        self.update_utmp = update_utmp
         super().__init__(latency, payload, log_input, log_output, log_window,
                          limit_rate, limit_burst, limit_action,
                          writer, file_writer_path, journal_priority,
@@ -215,7 +212,6 @@ class TlogRecSessionConfig(TlogRecConfig):
         tlog_rec_session_config = {
             "shell": self.shell,
             "notice": self.notice,
-            "update-utmp": self.update_utmp,
         }
 
         return tlog_rec_session_config

--- a/lib/tlitest/test_tlog_rec_session.py
+++ b/lib/tlitest/test_tlog_rec_session.py
@@ -214,21 +214,6 @@ class TestTlogRecSession:
         stdout_data = p.communicate(input=text_in_stdio)[0]
         assert text_out in stdout_data
 
-    def test_session_record_update_utmp(self):
-        """
-        Update_utmp functionality test
-        """
-        myname = inspect.stack()[0][3]
-        logfile = mklogfile(self.tempdir)
-        sessionclass = TlogRecSessionConfig(update_utmp=True,
-                                            writer="file",
-                                            file_writer_path=logfile)
-        sessionclass.generate_config(SYSTEM_TLOG_REC_SESSION_CONF)
-        shell = ssh_pexpect(self.user, 'Secret123', 'localhost')
-        shell.sendline('echo {}'.format(myname))
-        check_recording(shell, myname, logfile)
-        shell.close()
-
     @classmethod
     def teardown_class(cls):
         """ Copy original conf file back into place """

--- a/lib/tlog/rec.c
+++ b/lib/tlog/rec.c
@@ -1126,7 +1126,6 @@ tlog_rec(struct tlog_errs **perrs, uid_t euid, gid_t egid,
     unsigned int item_mask;
     int signal = 0;
     struct tlog_sink *log_sink = NULL;
-    bool update_utmp;
     struct tlog_tap tap = TLOG_TAP_VOID;
 
     assert(cmd_help != NULL);
@@ -1244,14 +1243,10 @@ tlog_rec(struct tlog_errs **perrs, uid_t euid, gid_t egid,
         fprintf(stderr, "%s", json_object_get_string(obj));
     }
 
-    /* Check if we will update utmp */
-    update_utmp = json_object_object_get_ex(conf, "update-utmp", &obj) &&
-        json_object_get_boolean(obj);
-
     /* Setup the tap */
     grc = tlog_tap_setup(perrs, &tap, euid, egid,
                          opts & TLOG_EXEC_OPT_MASK, path, argv,
-                         in_fd, out_fd, err_fd, clock_id, update_utmp);
+                         in_fd, out_fd, err_fd, clock_id);
     if (grc != TLOG_RC_OK) {
         TLOG_ERRS_RAISES("Failed setting up the I/O tap");
     }

--- a/m4/tlog/conf_cmd.m4
+++ b/m4/tlog/conf_cmd.m4
@@ -42,7 +42,7 @@ m4_define(
                     `
                         m4_print(
                             `        OPT',
-                            m4_translit(`$1/$2', `-/a-z', `__A-Z'),
+                            m4_translit(m4_translit(`$1/$2', `/', `_'), `a-z', `A-Z'),
                             ` = ',
                             `m4_singlequote(`$6')')
                         m4_printl(`,')
@@ -72,7 +72,7 @@ m4_define(
                     `
                         m4_print(
                             `        OPT',
-                            m4_translit(`$1/$2', `-/a-z', `__A-Z'))
+                            m4_translit(m4_translit(`$1/$2', `/', `_'), `a-z', `A-Z'))
                         m4_ifelse(
                             M4_FIRST(),
                             `true',
@@ -175,7 +175,7 @@ m4_define(
                    `            .name = "m4_substr(m4_translit(`$1/$2', `/', `-'), 1)",')
                 m4_print(
                    `            .val = OPT',
-                   m4_translit(`$1/$2', `-/a-z', `__A-Z'))
+                   m4_translit(m4_translit(`$1/$2', `/', `_'), `a-z', `A-Z'))
                 m4_printl(
                    `,',
                    `            .has_arg = $4,',
@@ -473,7 +473,7 @@ m4_define(
             `
                 m4_print(
                    `        case OPT',
-                   m4_translit(`$1/$2', `-/a-z', `__A-Z'))
+                   m4_translit(m4_translit(`$1/$2', `/', `_'), `a-z', `A-Z'))
                 m4_printl(
                     `:')
                 m4_print(

--- a/m4/tlog/rec_session_conf_schema.m4
+++ b/m4/tlog/rec_session_conf_schema.m4
@@ -61,16 +61,6 @@ M4_PARAM(`', `notice', `file-env',
                    `recording and the user shell. Can be used to warn',
                    `the user that the session is recorded.')')m4_dnl
 m4_dnl
-M4_PARAM(`', `update-utmp', `name-file-env',
-          `M4_TYPE_BOOL(false)', true,
-          `u', `', `Enable/disable updating the system utmp file',
-          `If specified, ', `If true, ',
-          `M4_LINES(`tlog-rec-session attempts to set a USER_PROCESS utmp entry.',
-                    `The recorded user must have permission to update the utmp',
-                    `file, likely as a member of the utmp group. Alternatively',
-                    `tlog-rec-session may be installed belonging to the utmp',
-                    `group and with the setgit bit set.')')m4_dnl
-m4_dnl
 m4_dnl
 m4_dnl Include common schema, but limit its scope to environment
 m4_dnl

--- a/src/tlitest/tlitest-setup
+++ b/src/tlitest/tlitest-setup
@@ -58,5 +58,4 @@ echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > \
 
 usermod tlitestlocaladmin1 -aG wheel,systemd-journal
 usermod tlitestlocaluser1 -aG systemd-journal
-usermod tlitestlocaluser2 -aG utmp
 usermod tlitestlocaluser2 -s /usr/bin/tlog-rec-session

--- a/tlog.spec
+++ b/tlog.spec
@@ -45,6 +45,7 @@ BuildRequires:  make
 %if "%{_vendor}" == "debbuild"
 BuildRequires:  libjson-c-dev
 BuildRequires:  libcurl4-gnutls-dev
+BuildRequires:  libutempter-dev
 # Debian/Ubuntu doesn't automatically pull this in...
 BuildRequires:  pkg-config
 
@@ -60,6 +61,7 @@ Requires(postun): systemd
 %else
 BuildRequires:  pkgconfig(json-c)
 BuildRequires:  pkgconfig(libcurl)
+BuildRequires:  libutempter-devel
 
 %if %{with systemd}
 BuildRequires:  pkgconfig(libsystemd)
@@ -77,7 +79,7 @@ in JSON format.
 %setup -q
 
 %build
-%configure --disable-rpath --disable-static %{!?with_systemd:--disable-journal}
+%configure --disable-rpath --disable-static --enable-utempter %{!?with_systemd:--disable-journal}
 %make_build
 
 %check


### PR DESCRIPTION
Configure tlog at build-time with `--enable-utempter` to enable writing utmp/wtmp entries with libutempter. This reverts https://github.com/Scribery/tlog/commit/60cc06f1b073eaa309422e135b4c5ac99f33c937

The privilege escalation/locking changes are needed because `utempter_remove_record` fails after the EUID privileges were locked due to:

https://github.com/altlinux/libutempter/blob/master/libutempter/utempter.c#L63