### PR TITLE
Require journal match filter

### DIFF
--- a/lib/tlog/play.c
+++ b/lib/tlog/play.c
@@ -199,6 +199,9 @@ tlog_play_create_journal_json_reader(struct tlog_errs **perrs,
                                  i + 1, str_list[i]);
             }
         }
+    } else {
+        grc = TLOG_RC_FAILURE;
+        TLOG_ERRS_RAISES("Journal match list not specified");
     }
 
     /* Create the reader */


### PR DESCRIPTION
Require and log an informative error message when the journal reader is used but no `-M` match filter was provided.

This improves the user experience and matches the Elasticsearch reader behavior when no baseurl is provided.