### PR TITLE
Add file reader match functionality

### DIFF
--- a/include/tlog/fd_json_reader.h
+++ b/include/tlog/fd_json_reader.h
@@ -43,18 +43,20 @@ extern const struct tlog_json_reader_type tlog_fd_json_reader_type;
  * @param fd_owned  True if the file descriptor should be closed upon
  *                  destruction of the reader, false otherwise.
  * @param size      Text buffer size (non-zero).
+ * @param match     Recording ID string to match, NULL if not provided.
  *
  * @return Global return code.
  */
 static inline tlog_grc
 tlog_fd_json_reader_create(struct tlog_json_reader **preader,
-                           int fd, bool fd_owned, size_t size)
+                           int fd, bool fd_owned, size_t size,
+                           const char *match)
 {
     assert(preader != NULL);
     assert(fd >= 0);
     assert(size > 0);
     return tlog_json_reader_create(preader, &tlog_fd_json_reader_type,
-                                   fd, fd_owned, size);
+                                   fd, fd_owned, size, match);
 }
 
 #endif /* _TLOG_FD_JSON_READER_H */

--- a/lib/tlitest/misc.py
+++ b/lib/tlitest/misc.py
@@ -5,6 +5,7 @@ import ast
 import stat
 import time
 import inspect
+import json
 from shutil import copyfile
 from systemd import journal
 
@@ -142,6 +143,20 @@ def mkrecording(shell, filename=None, sleep=3):
     else:
         opts = '-o {}'.format(filename)
     shell.sendline('tlog-rec {}'.format(opts))
+    time.sleep(sleep)
     shell.sendline('id')
     shell.sendline('cat /etc/hosts')
     shell.sendline('exit')
+
+def read_tlog_recording_file(recording_file):
+    """ Read tlog message(s) from file. JSON Objects are
+        decoded and returned into list of dictionaries.
+    """
+    messages = []
+
+    with open(recording_file) as f:
+        for line in f:
+            obj = json.loads(line)
+            messages.append(obj)
+
+    return messages

--- a/lib/tlog/play.c
+++ b/lib/tlog/play.c
@@ -241,6 +241,7 @@ tlog_play_create_file_json_reader(struct tlog_errs **perrs,
 {
     tlog_grc grc;
     const char *str;
+    const char *match;
     int fd = -1;
     struct tlog_json_reader *reader = NULL;
     struct json_object *obj;
@@ -255,6 +256,10 @@ tlog_play_create_file_json_reader(struct tlog_errs **perrs,
     }
     str = json_object_get_string(obj);
 
+    /* Get the recording to match, if any */
+    json_object_object_get_ex(conf, "match", &obj);
+    match = json_object_get_string(obj);
+
     /* Open the file */
     fd = open(str, O_RDONLY);
     if (fd < 0) {
@@ -263,7 +268,7 @@ tlog_play_create_file_json_reader(struct tlog_errs **perrs,
     }
 
     /* Create the reader, letting it take over the FD */
-    grc = tlog_fd_json_reader_create(&reader, fd, true, 65536);
+    grc = tlog_fd_json_reader_create(&reader, fd, true, 65536, match);
     if (grc != TLOG_RC_OK) {
         TLOG_ERRS_RAISECS(grc, "Failed creating file reader");
     }

--- a/m4/tlog/play_conf_schema.m4
+++ b/m4/tlog/play_conf_schema.m4
@@ -75,6 +75,13 @@ M4_PARAM(`/file', `path', `file-',
          `FILE is the ', `The ',
          `M4_LINES(`path to the file the "file" reader should read logs from.')')m4_dnl
 m4_dnl
+M4_PARAM(`/file', `match', `file-',
+         `M4_TYPE_STRING()', false,
+         `m', `=STRING', `Playback explicit recording id specified in STRING',
+         `STRING is the ', `The ',
+         `M4_LINES(`recording id of the recording the "file" reader should seek to',
+                   `for playback.')')m4_dnl
+m4_dnl
 m4_dnl
 m4_dnl
 M4_CONTAINER(`', `/es', `Elasticsearch reader')m4_dnl

--- a/src/tltest/tltest-fd-json-reader.c
+++ b/src/tltest/tltest-fd-json-reader.c
@@ -113,7 +113,7 @@ test(const char *file, int line, const char *n, const struct test t)
                 strerror(errno));
         exit(1);
     }
-    grc = tlog_fd_json_reader_create(&reader, fd, false, BUF_SIZE);
+    grc = tlog_fd_json_reader_create(&reader, fd, false, BUF_SIZE, NULL);
     if (grc != TLOG_RC_OK) {
         fprintf(stderr, "Failed creating FD reader: %s\n",
                 tlog_grc_strerror(grc));


### PR DESCRIPTION
Add a new `tlog-play` file-reader specific "match" **-m** option, accepts a string recording id value to determine which recording to playback. This option is only relevant when multiple tlog recordings are appended to the same file. 

Resolves https://github.com/Scribery/tlog/issues/277