### PR TITLE
Add timestamp output facility to tlog-play

### DIFF
--- a/lib/tlog/play.c
+++ b/lib/tlog/play.c
@@ -708,6 +708,7 @@ cleanup:
     return grc;
 }
 
+bool tlog_print_timestamp = false;
 /**
  * Read playback input, interpreting user input.
  *
@@ -892,6 +893,9 @@ tlog_play_run_read_input(struct tlog_errs **perrs, bool *pquit)
             case '\x7f':
                 tlog_play_speed = (struct timespec){1, 0};
                 break;
+	    case 'T':
+	      tlog_print_timestamp = !tlog_print_timestamp;
+	      break;
             case '}':
                 tlog_timespec_fp_mul(&tlog_play_speed, &accel,
                                      &new_speed);
@@ -985,6 +989,13 @@ tlog_play_run(struct tlog_errs **perrs, int *psignal)
         /* Handle pausing, unless ignoring timing */
         if (tlog_play_paused && !(tlog_play_goto_active || tlog_play_skip)) {
             do {
+	      if(tlog_print_timestamp) {
+		int hour = pkt.timestamp.tv_sec/3600;
+		int min = (pkt.timestamp.tv_sec-hour*3600)/60;
+		int sec = (pkt.timestamp.tv_sec-hour*3600-min*60);
+		printf("\r\nPaused at %02ld:%02ld:%02ld\r\n",hour,min,sec);
+	      }
+
                 rc = clock_nanosleep(CLOCK_MONOTONIC, 0,
                                      &tlog_timespec_max, NULL);
             } while (rc == 0);

--- a/lib/tlog/play.c
+++ b/lib/tlog/play.c
@@ -895,8 +895,8 @@ tlog_play_run_read_input(struct tlog_errs **perrs, bool *pquit)
                 tlog_play_speed = (struct timespec){1, 0};
                 break;
 	    case 'T':
-	      tlog_print_timestamp = !tlog_print_timestamp;
-	      break;
+	        tlog_print_timestamp = !tlog_print_timestamp;
+	        break;
             case '}':
                 tlog_timespec_fp_mul(&tlog_play_speed, &accel,
                                      &new_speed);
@@ -990,12 +990,12 @@ tlog_play_run(struct tlog_errs **perrs, int *psignal)
         /* Handle pausing, unless ignoring timing */
         if (tlog_play_paused && !(tlog_play_goto_active || tlog_play_skip)) {
             do {
-	      if(tlog_print_timestamp) {
-		int hour = pkt.timestamp.tv_sec/3600;
-		int min = (pkt.timestamp.tv_sec-hour*3600)/60;
-		int sec = (pkt.timestamp.tv_sec-hour*3600-min*60);
-		printf("\r\nPaused at %02ld:%02ld:%02ld\r\n",hour,min,sec);
-	      }
+                if(tlog_print_timestamp) {
+                    int hour = pkt.timestamp.tv_sec/3600;
+                    int min = (pkt.timestamp.tv_sec-hour*3600)/60;
+                    int sec = (pkt.timestamp.tv_sec-hour*3600-min*60);
+                    printf("\r\nPaused at %02ld:%02ld:%02ld\r\n",hour,min,sec);
+                }
 
                 rc = clock_nanosleep(CLOCK_MONOTONIC, 0,
                                      &tlog_timespec_max, NULL);

--- a/lib/tlog/play.c
+++ b/lib/tlog/play.c
@@ -462,7 +462,6 @@ struct timespec tlog_play_pkt_last_ts;
 /** Should output timestamp on pause */
 bool tlog_print_timestamp = false;
 
-
 /** True if playback state was initialized succesfully */
 bool tlog_play_initialized = false;
 

--- a/lib/tlog/play.c
+++ b/lib/tlog/play.c
@@ -994,7 +994,7 @@ tlog_play_run(struct tlog_errs **perrs, int *psignal)
                     int hour = pkt.timestamp.tv_sec/3600;
                     int min = (pkt.timestamp.tv_sec-hour*3600)/60;
                     int sec = (pkt.timestamp.tv_sec-hour*3600-min*60);
-                    printf("\r\nPaused at %02ld:%02ld:%02ld\r\n",hour,min,sec);
+                    printf("\r\nPaused at %02d:%02d:%02d\r\n",hour,min,sec);
                 }
 
                 rc = clock_nanosleep(CLOCK_MONOTONIC, 0,

--- a/lib/tlog/play.c
+++ b/lib/tlog/play.c
@@ -459,6 +459,9 @@ struct tlog_timestr_parser tlog_play_timestr_parser;
 struct timespec tlog_play_local_last_ts;
 /** Recording's time of packet output last */
 struct timespec tlog_play_pkt_last_ts;
+/** Should output timestamp on pause */
+bool tlog_print_timestamp = false;
+
 
 /** True if playback state was initialized succesfully */
 bool tlog_play_initialized = false;
@@ -708,7 +711,6 @@ cleanup:
     return grc;
 }
 
-bool tlog_print_timestamp = false;
 /**
  * Read playback input, interpreting user input.
  *


### PR DESCRIPTION
This patch adds the interactive command 'T' to tlog-play. Hitting 'T' during playback enables timestamp output. Whenever playback is paused, a timestamp is output on the console. This timestamp can then be used with -g on the command line to restart playback at the paused location. 