### PR TITLE
Added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ compiler:
 - clang
 - gcc
 os: linux
+arch:
+  - amd64
+  - ppc64le
 addons:
     apt:
         packages:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjay-cpu/tlog/builds/180817874 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!