### PR TITLE
Fix Upstream CI

### DIFF
--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -1,6 +1,6 @@
-FROM fedora:latest
+FROM fedora:rawhide
 COPY . .
-RUN dnf -y install autoconf \
+RUN dnf -y --nogpgcheck install autoconf \
                    automake \
                    make \
                    libtool \

--- a/src/tlitest/tlitest-setup
+++ b/src/tlitest/tlitest-setup
@@ -25,7 +25,7 @@ for P in $PKGS; do
     rpm -q "$P" > /dev/null
     if [ $? -ne 0 ]; then
         echo "RPM [$P] missing..installing"
-        dnf -y install $P
+        dnf -y --nogpgcheck install $P
     else
         echo "RPM [$P] already installed...saving"
         echo "$P" >> $PKGSFILE


### PR DESCRIPTION
It appears there is an annobin failure preventing rpmbuild on the latest stable fedora container image, update to rawhide for the time being.