### PR TITLE
Correct suse rpmbuild with included spec file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ before_install:
 - mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS,SDEBS,DEBS}
 - ln -sr ~/rpmbuild ~/debbuild
 before_script:
-- wget https://github.com/debbuild/debbuild/releases/download/18.8.1/debbuild_18.8.1-ascherer.ubuntu16.04_all.deb
-- sudo dpkg -i debbuild_18.8.1-ascherer.ubuntu16.04_all.deb
+- wget https://github.com/debbuild/debbuild/releases/download/20.12.1/debbuild_20.12.1-0ubuntu18.04_all.deb
+- sudo dpkg -i debbuild_20.12.1-0ubuntu18.04_all.deb
 - echo "%_default_verbosity 2" >> ~/.debmacros
 - autoreconf -i -f
 - $CLANG_SCAN_BUILD ./configure --disable-silent-rules $CONFIGURE_ARGS

--- a/tlog.spec
+++ b/tlog.spec
@@ -61,7 +61,11 @@ Requires(postun): systemd
 %else
 BuildRequires:  pkgconfig(json-c)
 BuildRequires:  pkgconfig(libcurl)
+%if %{defined suse_version}
+BuildRequires:  utempter-devel
+%else
 BuildRequires:  libutempter-devel
+%endif
 
 %if %{with systemd}
 BuildRequires:  pkgconfig(libsystemd)
@@ -79,7 +83,7 @@ in JSON format.
 %setup -q
 
 %build
-%configure --disable-rpath --disable-static --enable-utempter %{!?with_systemd:--disable-journal}
+%configure --disable-rpath --disable-static --enable-utempter %{!?with_systemd:--disable-journal} --docdir=%{_defaultdocdir}/%{name}
 %make_build
 
 %check

--- a/tlog.spec
+++ b/tlog.spec
@@ -9,6 +9,7 @@
 
 %if "%{_vendor}" == "debbuild"
 # Set values to make debian builds work well
+%global _defaultdocdir /usr/share/doc/%{name}
 %global _buildshell /bin/bash
 %global _lib lib/%(%{__dpkg_architecture} -qDEB_HOST_MULTIARCH)
 %endif


### PR DESCRIPTION
The package name in SuSE for the utempter devel package differs
from redhat.  Also, the default documentation directory differs
between these causing the configure script to choose a different
location than the %files section assumes.  This commit makes
minor adjustments to the build to allow rpmbuild to work on SuSE
out of the box.

I did not update the specfile changelog because the HEAD of master
already has tlog-10 listed, though this bug is present in tlog-9.