### PR TITLE
Fire SIGCHLD after utempter_add_record since it probably eats it.

### DIFF
--- a/lib/tlog/tap.c
+++ b/lib/tlog/tap.c
@@ -223,10 +223,12 @@ tlog_tap_setup(struct tlog_errs **perrs,
             }
 
 #ifdef HAVE_UTEMPTER
+        if (isatty(in_fd)) {
             if (utempter_add_record(master_fd, NULL) == 0) {
-		grc = TLOG_RC_FAILURE;
-		TLOG_ERRS_RAISES("Failed adding a utmp record");
-	    }
+                grc = TLOG_RC_FAILURE;
+                TLOG_ERRS_RAISES("Failed adding a utmp record");
+            }
+        }
 #endif
         }
     } else {


### PR DESCRIPTION
A short-lived command passed into tlog-rec{-session}
can cause SIGCHLD to be ignored during utmp record
addition.