### PR TITLE
tlitest: extend delay for limit-action delay test

### DIFF
--- a/lib/tlitest/misc.py
+++ b/lib/tlitest/misc.py
@@ -47,10 +47,10 @@ def check_journal(pattern):
     assert pattern in out_txt
 
 
-def check_outfile(pattern, filename):
+def check_outfile(pattern, filename, maxchecks=10):
     """ Check that file contains pattern """
     time.sleep(1)
-    for _ in range(0, 10):
+    for _ in range(0, maxchecks):
         file1 = open(filename, 'r')
         content = file1.read()
         file1.close()

--- a/lib/tlitest/test_tlog_rec_perf_opts.py
+++ b/lib/tlitest/test_tlog_rec_perf_opts.py
@@ -99,7 +99,7 @@ class TestTlogRecPerformanceOptions:
                        '-o {} /bin/bash'.format(opts, logfile))
         for num in range(0, 200):
             shell.sendline('echo test_{}'.format(num))
-        check_outfile('test_199', logfile)
+        check_outfile('test_199', logfile, maxchecks=100)
         shell.sendline('exit')
         check_recording(shell, 'test_199', logfile)
         shell.close()


### PR DESCRIPTION
In some environments the limit-action delay test listed below is
failing:

test_record_fast_input_with_limit_action_delay

This requires more time to write to the output log file set by
tlog-rec in the test.  In order to accomplish this, the check_outfile
misc function is modified to take a parameter called maxchecks which can
be used to set how many times to check for a string in the file in
between the 5 second delays.

For the limit-action delay test, this is set to 100 to wait long enough
to catch the last message being written to the log file.