### PR TITLE
Address journal namespace fixes

### DIFF
--- a/Common.am
+++ b/Common.am
@@ -28,7 +28,8 @@ pkgconfdefaultdir = $(pkgdatadir)
 M4FLAGS = \
     -I $(top_srcdir)/m4/tlog                        \
     --prefix-builtins                               \
-    -D M4_JOURNAL_ENABLED=$(TLOG_JOURNAL_ENABLED)
+    -D M4_JOURNAL_ENABLED=$(TLOG_JOURNAL_ENABLED)   \
+    -D M4_JOURNAL_NAMESPACE=$(TLOG_JOURNAL_NAMESPACE)
 
 # Common configuration info dependencies
 TLOG_CONF_DEPS = \

--- a/configure.ac
+++ b/configure.ac
@@ -91,12 +91,17 @@ if test "$tlog_journal_enabled" = "yes"; then
     AC_DEFINE([TLOG_JOURNAL_ENABLED], [1],
               [Define to 1 if Systemd Journal support is enabled])
     PKG_CHECK_MODULES([SYSTEMD_JOURNAL], [libsystemd >= 245],
-                      AC_DEFINE(HAVE_JOURNAL_OPEN_NAMESPACE, 1,
-                                [Defined if systemd has namespace support]))
+                      [tlog_journal_namespace="yes"],
+                      [tlog_journal_namespace="no"])
 else
     AC_SUBST([TLOG_JOURNAL_ENABLED], [0])
 fi
 AM_CONDITIONAL([TLOG_JOURNAL_ENABLED], [test "$tlog_journal_enabled" = "yes"])
+if test "$tlog_journal_namespace" = "yes"; then
+    AC_SUBST([TLOG_JOURNAL_NAMESPACE], [1])
+    AC_DEFINE([TLOG_JOURNAL_NAMESPACE], [1],
+              [Define to 1 if Systemd Journal support is enabled])
+fi
 
 LIBCURL_CHECK_CONFIG([yes], [7.15.4], ,
                      AC_MSG_ERROR([libcurl not found]))

--- a/include/tlog/rc.h
+++ b/include/tlog/rc.h
@@ -54,7 +54,6 @@ typedef enum tlog_rc {
     TLOG_RC_ES_JSON_READER_CURL_INIT_FAILED,
     TLOG_RC_ES_JSON_READER_REPLY_INVALID,
     TLOG_RC_MEM_JSON_READER_INCOMPLETE_LINE,
-    TLOG_RC_SYSTEMD_NAMESPACE_NOT_SUPPORTED,
     /* Return code upper boundary (not a valid return code) */
     TLOG_RC_MAX_PLUS_ONE
 } tlog_rc;

--- a/lib/tlog/journal_json_reader.c
+++ b/lib/tlog/journal_json_reader.c
@@ -78,15 +78,14 @@ tlog_journal_json_reader_init(struct tlog_json_reader *reader, va_list ap)
     }
 
     /* Open journal */
-#if HAVE_JOURNAL_OPEN_NAMESPACE == 1
+#ifdef TLOG_JOURNAL_NAMESPACE
     sd_rc = sd_journal_open_namespace(&journal_json_reader->journal, namespace, 0);
-#else
-    if (namespace != NULL) {
-        grc = TLOG_RC_SYSTEMD_NAMESPACE_NOT_SUPPORTED;
+    if (sd_rc < 0) {
+        grc = TLOG_GRC_FROM(systemd, sd_rc);
         goto error;
     }
-    sd_rc = sd_journal_open(&journal_json_reader->journal, 0);
 #endif
+    sd_rc = sd_journal_open(&journal_json_reader->journal, 0);
     if (sd_rc < 0) {
         grc = TLOG_GRC_FROM(systemd, sd_rc);
         goto error;

--- a/m4/tlog/play_conf_schema.m4
+++ b/m4/tlog/play_conf_schema.m4
@@ -134,11 +134,14 @@ M4_PARAM(`/journal', `match', `opts-',
                    `string signifying disjunction or conjunction, as with',
                    `sd_journal_add_disjunction(3) and sd_journal_add_conjunction(3)')')m4_dnl
 m4_dnl
+m4_ifelse(M4_JOURNAL_NAMESPACE(), `1', `m4_dnl
+m4_dnl
 M4_PARAM(`/journal', `namespace', `opts-',
          `M4_TYPE_STRING()', true,
          `N', `=STRING', `Search for the records in STRING namespace only',
          `STRING is the ', `The ',
          `M4_LINES(`Specifies a specific journal namespace to use.')')m4_dnl
+')m4_dnl m4_ifelse M4_JOURNAL_NAMESPACE
 m4_dnl
 ')m4_dnl m4_ifelse M4_JOURNAL_ENABLED
 m4_dnl


### PR DESCRIPTION
Fix the hard failure building tlog in distros like RHEL8 due to:
~~~
   configure: error: Package requirements (libsystemd >= 245) were not met:
~~~

Build the -N namespace m4 man page option conditionally, this results in no need to handle catching  -N to tlog-play if namespace support is not built (as it will be an unknown option).