### PR TITLE
Prevent infinite transfer loop on GDM login

### DIFF
--- a/lib/tlog/rec.c
+++ b/lib/tlog/rec.c
@@ -934,21 +934,24 @@ tlog_rec_transfer(struct tlog_errs    **perrs,
             continue;
         }
 
-        /* Log the received data, if any */
-        if (tlog_pkt_pos_is_in(&log_pos, &pkt)) {
-            /* If asked to log this type of packet */
-            if (item_mask & (1 << tlog_rec_item_from_pkt(&pkt))) {
-                grc = tlog_sink_write(log_sink, &pkt, &log_pos, NULL);
-                if (grc == TLOG_RC_OK) {
-                    log_pending = true;
-                } else if (grc != TLOG_GRC_FROM(errno, EINTR)) {
-                    return_grc = grc;
-                    TLOG_ERRS_RAISECS(grc, "Failed logging terminal data");
+        /* No data to log from EOF packet */
+        if (!tlog_pkt_is_eof(&pkt)) {
+            /* Log the received data, if any */
+            if (tlog_pkt_pos_is_in(&log_pos, &pkt)) {
+                /* If asked to log this type of packet */
+                if (item_mask & (1 << tlog_rec_item_from_pkt(&pkt))) {
+                    grc = tlog_sink_write(log_sink, &pkt, &log_pos, NULL);
+                    if (grc == TLOG_RC_OK) {
+                        log_pending = true;
+                    } else if (grc != TLOG_GRC_FROM(errno, EINTR)) {
+                        return_grc = grc;
+                        TLOG_ERRS_RAISECS(grc, "Failed logging terminal data");
+                    }
+                } else {
+                    tlog_pkt_pos_move_past(&log_pos, &pkt);
                 }
-            } else {
-                tlog_pkt_pos_move_past(&log_pos, &pkt);
+                continue;
             }
-            continue;
         }
 
         /* Read new data */
@@ -965,6 +968,9 @@ tlog_rec_transfer(struct tlog_errs    **perrs,
                 tlog_errs_pushs(perrs, "Failed reading terminal data");
                 return_grc = grc;
             }
+        /* No more active File Descriptors to read */
+        } else if (tlog_pkt_is_void(&pkt)) {
+            break;
         } else if (tlog_pkt_is_eof(&pkt)) {
             tlog_sink_io_close(tty_sink, pkt.data.io.output);
         }


### PR DESCRIPTION
Log write is attempted over and over on receipt of an EOF packet
when logging into GDM as a user tlog-rec-session as their shell.

Break out of the recording loop properly when a void packet is read from
the source - all FDs are marked inactive.