### PR TITLE
 Improved spec file to latest standards and fixed changelog

### DIFF
--- a/tlog-tmpfiles.conf
+++ b/tlog-tmpfiles.conf
@@ -1,0 +1,2 @@
+# Type  Path            Mode    UID     GID
+d       /run/tlog       0755    tlog    tlog


### PR DESCRIPTION
* Removed tmpfilesdir conditions, added systemd-rpm-macros as build
requirement
* Replacing short command options with the long notation, e.g. -m is
now --mode
* Removed compatibility macros, not needed anymore
* Cleaned up build dependencies
* Removed ldconfig commands from post and postun
* Bumped version to 12th release