### PR TITLE
configure: correctly handle systemd versions before 245

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,7 @@ if test "$tlog_journal_enabled" = "yes"; then
     AC_SUBST([TLOG_JOURNAL_ENABLED], [1])
     AC_DEFINE([TLOG_JOURNAL_ENABLED], [1],
               [Define to 1 if Systemd Journal support is enabled])
-    PKG_CHECK_MODULES([SYSTEMD_JOURNAL], [libsystemd >= 245],
+    PKG_CHECK_MODULES([SYSTEMD_JOURNAL_NAMESPACE], [libsystemd >= 245],
                       [tlog_journal_namespace="yes"],
                       [tlog_journal_namespace="no"])
 else


### PR DESCRIPTION
PKG_CHECK_MODULES macros need to have unique prefixes, or the latter ones are ignored. In configure.ac we were checking for SYSTEMD_JOURNAL twice, once for the presence of systemd in general, then again for namespace support. However, since the first call would already set the variables, the second check would re-use those.

This results in namespace support getting enabled in systemd versions that don't support it, and the build failing.