### PR TITLE
test_session_record_pipe_io_stdin: remove sshpass

### DIFF
--- a/.github/workflows/intg.yml
+++ b/.github/workflows/intg.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build the Docker image
-      run: sudo podman build . --file Dockerfile.fedora --tag ${IMAGE}
+      run: sudo -E XDG_RUNTIME_DIR= podman build . --file Dockerfile.fedora --tag ${IMAGE}
     - name: Run the container
       run: sudo podman run --privileged --security-opt seccomp=unconfined --detach -p 80:80 --name=${CONTAINER} ${IMAGE}
     - name: Check the container is up

--- a/lib/tlitest/test_tlog_rec_session.py
+++ b/lib/tlitest/test_tlog_rec_session.py
@@ -217,10 +217,14 @@ class TestTlogRecSession:
         """
         text_in_stdio = 'print("hello world")\n'
         text_out = "hello world"
-        p = Popen(['sshpass', '-p', 'Secret123', 'ssh', '-o',
-                   'StrictHostKeyChecking=no',
-                   'tlitestlocaluser2@localhost', 'python3'],
-        stdout=PIPE, stdin=PIPE, stderr=PIPE, encoding='utf8')
+
+        sessionclass = TlogRecSessionConfig(writer="syslog")
+        sessionclass.generate_config(SYSTEM_TLOG_REC_SESSION_CONF)
+
+        p = Popen(['ssh', '-i', f'~/.ssh/id_rsa_{self.user}',
+                   '-o', 'StrictHostKeyChecking=no',
+                   f'{self.user}@localhost', 'python3'],
+                  stdout=PIPE, stdin=PIPE, stderr=PIPE, encoding='utf8')
         stdout_data = p.communicate(input=text_in_stdio)[0]
         assert text_out in stdout_data
 

--- a/src/tlitest/tlitest-setup
+++ b/src/tlitest/tlitest-setup
@@ -8,7 +8,6 @@ python3-pytest
 python3-pexpect
 python3-systemd
 tcsh
-sshpass
 "
 
 [[ -z "${CONTAINER_ENV}" ]] && PKGS+="tlog"
@@ -61,3 +60,12 @@ echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > \
 usermod tlitestlocaladmin1 -aG wheel,systemd-journal
 usermod tlitestlocaluser1 -aG systemd-journal
 usermod tlitestlocaluser2 -s /usr/bin/tlog-rec-session
+
+# Generate ssh key for testing
+user="tlitestlocaluser2"
+rm -rf ~/.ssh/id_rsa_${user}*
+ssh-keygen -t rsa -b 2048 -N "" -C stdin_test -f ~/.ssh/id_rsa_${user}
+user_dir=$(eval echo "~${user}")
+mkdir -p ${user_dir}/.ssh
+cat ~/.ssh/id_rsa_${user}.pub >> ${user_dir}/.ssh/authorized_keys
+chown -R ${user}:${user} ${user_dir}/.ssh

--- a/src/tlitest/tlitest-teardown
+++ b/src/tlitest/tlitest-teardown
@@ -48,3 +48,8 @@ if [ -f /etc/sudoers.d/01_wheel_nopass_tlitest ]; then
     echo "Found test sudoers file...removing"
     rm /etc/sudoers.d/01_wheel_nopass_tlitest
 fi
+
+user="tlitestlocaluser2"
+if [ -f ~/.ssh/id_rsa_${user} ]; then
+    rm -rf ~/.ssh/id_rsa_${user}*
+fi


### PR DESCRIPTION
Removing reliance on sshpass by adding code in test case to generate an ssh key and remove it after testing.