### PR TITLE
Add missing argument for sigchld handler

### DIFF
--- a/lib/tlog/rec.c
+++ b/lib/tlog/rec.c
@@ -78,7 +78,7 @@ tlog_rec_alarm_sighandler(int signum)
 }
 
 static void
-tlog_rec_sigchld_handler()
+tlog_rec_sigchld_handler(int signum)
 {
     tlog_rec_child_exited = true;
 }


### PR DESCRIPTION
rec.c: In function 'tlog_rec_transfer':
rec.c:877:19: error: assignment to '__sighandler_t' {aka 'void (*)(int)'} from incompatible pointer type 'void (*)(void)' [-Wincompatible-pointer-types]
  877 |     sa.sa_handler = tlog_rec_sigchld_handler;
      |                   ^
rec.c:81:1: note: 'tlog_rec_sigchld_handler' declared here
   81 | tlog_rec_sigchld_handler()
      | ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from rec.c:45:
/usr/include/signal.h:72:16: note: '__sighandler_t' declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
make[4]: *** [Makefile:734: rec.lo] Error 1